### PR TITLE
Fix redirect loop causing production errors

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -11,5 +11,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|public/).*)"],
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|public|login|register|privacy|terms|support|contact).+)",
+  ],
 };


### PR DESCRIPTION
The middleware was causing ERR_TOO_MANY_REDIRECTS by redirecting unauthenticated users to "/" while also running on "/" itself.

Changes:
- Changed matcher from `.*` to `.+` to exclude root path "/" from middleware
- Added public pages (login, register, privacy, terms, support, contact) to the exclusion list so they don't require authentication