### PR TITLE
Fix implicit any type lint warning in series list page

### DIFF
--- a/src/app/(main)/[organization]/series/page.tsx
+++ b/src/app/(main)/[organization]/series/page.tsx
@@ -12,7 +12,7 @@ export default async function SeriesListPage({ params }: { params: Promise<{ org
   const session = await auth.api.getSession({ headers: headersList });
 
   // Get organization by slug
-  let organizationData;
+  let organizationData: Awaited<ReturnType<typeof getCachedOrganizationBySlug>>;
   try {
     organizationData = await getCachedOrganizationBySlug(organization);
   } catch {


### PR DESCRIPTION
Add explicit type annotation for organizationData variable to satisfy biome's noImplicitAnyLet rule.