### PR TITLE
Implement password reset and invitation flows

### DIFF
--- a/src/app/(auth)/accept-invitation/[id]/page.tsx
+++ b/src/app/(auth)/accept-invitation/[id]/page.tsx
@@ -1,0 +1,36 @@
+import { AcceptInvitationForm } from "@/components/auth/accept-invitation-form";
+import { env } from "@/lib/env/server";
+
+async function getInvitation(id: string) {
+  try {
+    // Use absolute URL for server-side fetch
+    const response = await fetch(`${env.APP_URL}/api/invitations/${id}`, {
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json();
+    return data.success ? data.data : null;
+  } catch (error) {
+    console.error("Error fetching invitation:", error);
+    return null;
+  }
+}
+
+interface AcceptInvitationPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function AcceptInvitationPage({ params }: AcceptInvitationPageProps) {
+  const { id } = await params;
+  const invitation = await getInvitation(id);
+
+  return (
+    <div className="w-full max-w-md">
+      <AcceptInvitationForm invitation={invitation} />
+    </div>
+  );
+}

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react";
+import { ForgotPasswordForm } from "@/components/auth/forgot-password-form";
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="w-full max-w-md">
+      <Suspense fallback={<div>Loading...</div>}>
+        <ForgotPasswordForm />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react";
+import { ResetPasswordForm } from "@/components/auth/reset-password-form";
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="w-full max-w-md">
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordForm />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/api/invitations/[id]/route.ts
+++ b/src/app/api/invitations/[id]/route.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { invitations, organizations, users } from "@/lib/db/schema";
+import type { ApiResponse } from "@/lib/types";
+
+// =============================================================================
+// GET /api/invitations/[id] - Get invitation details
+// =============================================================================
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+
+    // Fetch invitation with organization and inviter details
+    const invitation = await db
+      .select({
+        id: invitations.id,
+        email: invitations.email,
+        role: invitations.role,
+        status: invitations.status,
+        expiresAt: invitations.expiresAt,
+        organizationId: invitations.organizationId,
+        inviterId: invitations.inviterId,
+        organization: {
+          id: organizations.id,
+          name: organizations.name,
+          slug: organizations.slug,
+          logo: organizations.logo,
+        },
+        inviter: {
+          id: users.id,
+          name: users.name,
+          image: users.image,
+        },
+      })
+      .from(invitations)
+      .innerJoin(organizations, eq(invitations.organizationId, organizations.id))
+      .innerJoin(users, eq(invitations.inviterId, users.id))
+      .where(eq(invitations.id, id))
+      .limit(1);
+
+    if (!invitation[0]) {
+      const response: ApiResponse = {
+        success: false,
+        error: "Invitation not found",
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    const response: ApiResponse = {
+      success: true,
+      data: invitation[0],
+    };
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error("[GET /api/invitations/[id]]", error);
+    const response: ApiResponse = {
+      success: false,
+      error: "Internal server error",
+    };
+    return NextResponse.json(response, { status: 500 });
+  }
+}

--- a/src/components/auth/accept-invitation-form.tsx
+++ b/src/components/auth/accept-invitation-form.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Loader2, LogOut, UserPlus, XCircle } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { authClient } from "@/lib/auth-client";
+import { useToast } from "@/hooks/use-toast";
+
+interface Invitation {
+  id: string;
+  email: string;
+  role: string;
+  status: string;
+  expiresAt: string;
+  organizationId: string;
+  inviterId: string;
+  organization: {
+    id: string;
+    name: string;
+    slug: string | null;
+    logo: string | null;
+  };
+  inviter: {
+    id: string;
+    name: string;
+    image: string | null;
+  };
+}
+
+interface AcceptInvitationFormProps {
+  invitation: Invitation | null;
+  error?: string | null;
+}
+
+export function AcceptInvitationForm({ invitation, error }: AcceptInvitationFormProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const { data: session, isPending: isSessionLoading } = authClient.useSession();
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [isDeclining, setIsDeclining] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  // Loading state while checking session
+  if (isSessionLoading) {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardContent className="py-12 flex justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 1. Error or not found
+  if (error || !invitation) {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-red-100 rounded-full">
+              <XCircle className="h-8 w-8 text-red-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Invitation Not Found</CardTitle>
+          <CardDescription className="text-center">
+            {error || "This invitation doesn't exist or has been cancelled."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button className="w-full" asChild>
+            <Link href="/">Go to Home</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 2. Expired invitation
+  const isExpired = new Date(invitation.expiresAt) < new Date();
+  if (isExpired) {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-orange-100 rounded-full">
+              <AlertCircle className="h-8 w-8 text-orange-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Invitation Expired</CardTitle>
+          <CardDescription className="text-center">
+            This invitation to join <strong>{invitation.organization.name}</strong> has expired. Please ask{" "}
+            {invitation.inviter.name} to send you a new invitation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button className="w-full" asChild>
+            <Link href="/">Go to Home</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 3. Already accepted - redirect
+  if (invitation.status === "accepted") {
+    const orgSlug = invitation.organization.slug || invitation.organizationId;
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-green-100 rounded-full">
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Already Accepted</CardTitle>
+          <CardDescription className="text-center">
+            You've already joined <strong>{invitation.organization.name}</strong>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button className="w-full" asChild>
+            <Link href={`/${orgSlug}`}>Go to {invitation.organization.name}</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 4. Not logged in - show login/signup options
+  if (!session) {
+    const invitationId = invitation.id;
+    const redirectPath = `/accept-invitation/${invitationId}`;
+    const loginUrl = `/login?redirectTo=${encodeURIComponent(redirectPath)}`;
+    const registerUrl = `/register?redirectTo=${encodeURIComponent(redirectPath)}&email=${encodeURIComponent(invitation.email)}`;
+
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            {invitation.organization.logo ? (
+              <Avatar className="h-16 w-16">
+                <AvatarImage src={invitation.organization.logo} alt={invitation.organization.name} />
+                <AvatarFallback className="text-lg">{invitation.organization.name[0]?.toUpperCase()}</AvatarFallback>
+              </Avatar>
+            ) : (
+              <div className="p-3 bg-primary/10 rounded-full">
+                <UserPlus className="h-8 w-8 text-primary" />
+              </div>
+            )}
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">
+            You're invited to join {invitation.organization.name}
+          </CardTitle>
+          <CardDescription className="text-center">
+            <span className="font-medium">{invitation.inviter.name}</span> invited you as a{" "}
+            <span className="font-medium capitalize">{invitation.role}</span>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-center text-muted-foreground">
+            Sign in or create an account to accept this invitation.
+          </p>
+          <div className="flex flex-col gap-3">
+            <Button className="w-full" asChild>
+              <Link href={loginUrl}>Sign In</Link>
+            </Button>
+            <Button variant="outline" className="w-full" asChild>
+              <Link href={registerUrl}>Create Account</Link>
+            </Button>
+          </div>
+        </CardContent>
+        <CardFooter className="text-center text-xs text-muted-foreground">
+          <p className="w-full">Invitation sent to {invitation.email}</p>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  // 5. Logged in as different email than invited
+  if (session.user.email !== invitation.email) {
+    const handleSignOut = async () => {
+      setIsSigningOut(true);
+      try {
+        await authClient.signOut();
+        router.refresh();
+      } catch (err) {
+        console.error("Sign out error:", err);
+        setIsSigningOut(false);
+      }
+    };
+
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-orange-100 rounded-full">
+              <AlertCircle className="h-8 w-8 text-orange-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Wrong Account</CardTitle>
+          <CardDescription className="text-center">
+            This invitation was sent to a different email address.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="bg-muted rounded-lg p-4 space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Invitation for:</span>
+              <span className="font-medium">{invitation.email}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Signed in as:</span>
+              <span className="font-medium">{session.user.email}</span>
+            </div>
+          </div>
+          <Button className="w-full" onClick={handleSignOut} disabled={isSigningOut}>
+            {isSigningOut ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Signing out...
+              </>
+            ) : (
+              <>
+                <LogOut className="mr-2 h-4 w-4" />
+                Sign out and use correct account
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 6. Correct user - show accept/decline
+  const handleAccept = async () => {
+    setIsAccepting(true);
+    try {
+      const result = await authClient.organization.acceptInvitation({
+        invitationId: invitation.id,
+      });
+
+      if (result.error) {
+        toast({
+          title: "Error",
+          description: result.error.message || "Failed to accept invitation",
+          variant: "destructive",
+        });
+        setIsAccepting(false);
+        return;
+      }
+
+      // Send notification to inviter
+      try {
+        await fetch("/api/notifications", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            userId: invitation.inviterId,
+            type: "invitation_accepted",
+            title: `${session.user.name} joined ${invitation.organization.name}`,
+            body: `Your invitation was accepted.`,
+            resourceType: "organization",
+            resourceId: invitation.organizationId,
+            actorId: session.user.id,
+          }),
+        });
+      } catch (notificationError) {
+        // Don't block on notification failure
+        console.error("Failed to send notification:", notificationError);
+      }
+
+      toast({
+        title: "Welcome!",
+        description: `You've joined ${invitation.organization.name}`,
+      });
+
+      const orgSlug = invitation.organization.slug || invitation.organizationId;
+      router.push(`/${orgSlug}`);
+      router.refresh();
+    } catch (err) {
+      console.error("Accept invitation error:", err);
+      toast({
+        title: "Error",
+        description: "Failed to accept invitation. Please try again.",
+        variant: "destructive",
+      });
+      setIsAccepting(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    setIsDeclining(true);
+    try {
+      const result = await authClient.organization.rejectInvitation({
+        invitationId: invitation.id,
+      });
+
+      if (result.error) {
+        toast({
+          title: "Error",
+          description: result.error.message || "Failed to decline invitation",
+          variant: "destructive",
+        });
+        setIsDeclining(false);
+        return;
+      }
+
+      toast({
+        title: "Invitation declined",
+        description: "The invitation has been declined.",
+      });
+
+      router.push("/");
+      router.refresh();
+    } catch (err) {
+      console.error("Decline invitation error:", err);
+      toast({
+        title: "Error",
+        description: "Failed to decline invitation. Please try again.",
+        variant: "destructive",
+      });
+      setIsDeclining(false);
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader className="space-y-1">
+        <div className="flex justify-center mb-4">
+          {invitation.organization.logo ? (
+            <Avatar className="h-16 w-16">
+              <AvatarImage src={invitation.organization.logo} alt={invitation.organization.name} />
+              <AvatarFallback className="text-lg">{invitation.organization.name[0]?.toUpperCase()}</AvatarFallback>
+            </Avatar>
+          ) : (
+            <div className="p-3 bg-primary/10 rounded-full">
+              <UserPlus className="h-8 w-8 text-primary" />
+            </div>
+          )}
+        </div>
+        <CardTitle className="text-2xl font-bold text-center">Join {invitation.organization.name}</CardTitle>
+        <CardDescription className="text-center">
+          <span className="font-medium">{invitation.inviter.name}</span> invited you as a{" "}
+          <span className="font-medium capitalize">{invitation.role}</span>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-col gap-3">
+          <Button className="w-full" onClick={handleAccept} disabled={isAccepting || isDeclining}>
+            {isAccepting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Accepting...
+              </>
+            ) : (
+              "Accept Invitation"
+            )}
+          </Button>
+          <Button variant="outline" className="w-full" onClick={handleDecline} disabled={isAccepting || isDeclining}>
+            {isDeclining ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Declining...
+              </>
+            ) : (
+              "Decline"
+            )}
+          </Button>
+        </div>
+      </CardContent>
+      <CardFooter className="text-center text-xs text-muted-foreground">
+        <p className="w-full">Signed in as {session.user.email}</p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { ArrowLeft, CheckCircle2, Loader2, Mail } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { forgotPasswordSchema } from "@/lib/validations/schemas";
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    // Validate email using schema
+    const result = forgotPasswordSchema.safeParse({ email });
+    if (!result.success) {
+      setError(result.error.issues[0]?.message || "Please enter a valid email address");
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      // Use direct fetch to the auth API endpoint
+      await fetch("/api/auth/forget-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          redirectTo: "/reset-password",
+        }),
+      });
+
+      // Always show success regardless of whether email exists (security best practice)
+      // The API returns success even if the email doesn't exist to prevent enumeration
+      setIsSuccess(true);
+    } catch (err) {
+      // Don't reveal if the email exists or not
+      setIsSuccess(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isSuccess) {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-green-100 rounded-full">
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Check your email</CardTitle>
+          <CardDescription className="text-center">
+            If an account exists for <strong>{email}</strong>, we've sent a password reset link.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="text-sm text-muted-foreground text-center space-y-2">
+            <p>The link will expire in 1 hour.</p>
+            <p>Didn't receive the email? Check your spam folder or try again.</p>
+          </div>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              setIsSuccess(false);
+              setEmail("");
+            }}
+          >
+            <Mail className="mr-2 h-4 w-4" />
+            Try a different email
+          </Button>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <Button variant="link" className="p-0 h-auto font-normal" asChild>
+            <Link href="/login">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to login
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl font-bold text-center">Forgot password?</CardTitle>
+        <CardDescription className="text-center">
+          Enter your email address and we'll send you a link to reset your password.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="your.email@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={isLoading}
+              autoFocus
+            />
+          </div>
+          {error && <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">{error}</div>}
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Sending reset link...
+              </>
+            ) : (
+              "Send reset link"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+      <CardFooter className="flex justify-center">
+        <Button variant="link" className="p-0 h-auto font-normal" asChild>
+          <Link href="/login">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to login
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -88,7 +88,12 @@ export function LoginForm({ redirectTo }: LoginFormProps) {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="password">Password</Label>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="password">Password</Label>
+              <Button variant="link" className="p-0 h-auto font-normal text-sm" asChild>
+                <a href="/forgot-password">Forgot password?</a>
+              </Button>
+            </div>
             <div className="relative">
               <Input
                 id="password"

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -15,19 +15,21 @@ interface RegisterFormProps {
 }
 
 export function RegisterForm({ redirectTo }: RegisterFormProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Get redirect URL and prefilled email from search params
+  const finalRedirectTo = redirectTo || searchParams.get("redirectTo") || "/onboarding";
+  const prefilledEmail = searchParams.get("email") || "";
+
   const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(prefilledEmail);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  // Get redirect URL from search params or use default
-  const finalRedirectTo = redirectTo || searchParams.get("redirectTo") || "/onboarding";
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -56,8 +58,9 @@ export function RegisterForm({ redirectTo }: RegisterFormProps) {
       if (result.error) {
         setError(result.error.message || "Failed to create account");
       } else {
-        // Redirect to verification pending page with email
-        router.push(`/verification-pending?email=${encodeURIComponent(email)}`);
+        // Redirect to verification pending page with email and redirect URL
+        const verificationUrl = `/verification-pending?email=${encodeURIComponent(email)}${finalRedirectTo !== "/onboarding" ? `&redirectTo=${encodeURIComponent(finalRedirectTo)}` : ""}`;
+        router.push(verificationUrl);
       }
     } catch (err) {
       setError("An unexpected error occurred");

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { AlertCircle, ArrowLeft, CheckCircle2, Eye, EyeOff, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { authClient } from "@/lib/auth-client";
+import { resetPasswordSchema } from "@/lib/validations/schemas";
+
+export function ResetPasswordForm() {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  useEffect(() => {
+    if (!token) {
+      setTokenError("No reset token provided. Please request a new password reset link.");
+    }
+  }, [token]);
+
+  const getPasswordStrength = (pwd: string): { strength: number; label: string; color: string } => {
+    let strength = 0;
+    if (pwd.length >= 8) strength++;
+    if (pwd.length >= 12) strength++;
+    if (/[a-z]/.test(pwd) && /[A-Z]/.test(pwd)) strength++;
+    if (/\d/.test(pwd)) strength++;
+    if (/[^a-zA-Z0-9]/.test(pwd)) strength++;
+
+    if (strength <= 1) return { strength: 1, label: "Weak", color: "bg-red-500" };
+    if (strength <= 2) return { strength: 2, label: "Fair", color: "bg-orange-500" };
+    if (strength <= 3) return { strength: 3, label: "Good", color: "bg-yellow-500" };
+    if (strength <= 4) return { strength: 4, label: "Strong", color: "bg-green-500" };
+    return { strength: 5, label: "Very Strong", color: "bg-green-600" };
+  };
+
+  const passwordStrength = getPasswordStrength(password);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    // Validate using schema
+    const result = resetPasswordSchema.safeParse({ password, confirmPassword, token });
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      setError(firstError?.message || "Please check your input");
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = await authClient.resetPassword({
+        newPassword: password,
+        token,
+      });
+
+      if (response.error) {
+        if (response.error.message?.toLowerCase().includes("expired")) {
+          setTokenError("This reset link has expired. Please request a new one.");
+        } else if (response.error.message?.toLowerCase().includes("invalid")) {
+          setTokenError("This reset link is invalid. Please request a new one.");
+        } else {
+          setError(response.error.message || "Failed to reset password");
+        }
+      } else {
+        setIsSuccess(true);
+        // Redirect to login after 3 seconds
+        setTimeout(() => {
+          router.push("/login");
+        }, 3000);
+      }
+    } catch (err) {
+      setError("An unexpected error occurred. Please try again.");
+      console.error("Reset password error:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (tokenError) {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-red-100 rounded-full">
+              <AlertCircle className="h-8 w-8 text-red-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Invalid Reset Link</CardTitle>
+          <CardDescription className="text-center">{tokenError}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button className="w-full" asChild>
+            <Link href="/forgot-password">Request New Reset Link</Link>
+          </Button>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <Button variant="link" className="p-0 h-auto font-normal" asChild>
+            <Link href="/login">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to login
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  if (isSuccess) {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="space-y-1">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-green-100 rounded-full">
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold text-center">Password Reset Successful</CardTitle>
+          <CardDescription className="text-center">
+            Your password has been reset. You'll be redirected to login in a moment.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button className="w-full" asChild>
+            <Link href="/login">Sign in now</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl font-bold text-center">Reset your password</CardTitle>
+        <CardDescription className="text-center">Enter your new password below.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="password">New Password</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="Enter your new password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={isLoading}
+                minLength={8}
+                autoFocus
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                onClick={() => setShowPassword(!showPassword)}
+                disabled={isLoading}
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+            {password && (
+              <div className="space-y-2">
+                <div className="flex gap-1">
+                  {[1, 2, 3, 4, 5].map((level) => (
+                    <div
+                      key={level}
+                      className={`h-1.5 flex-1 rounded-full transition-colors ${
+                        level <= passwordStrength.strength ? passwordStrength.color : "bg-gray-200"
+                      }`}
+                    />
+                  ))}
+                </div>
+                <p className="text-xs text-muted-foreground">Password strength: {passwordStrength.label}</p>
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">Minimum 8 characters</p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">Confirm Password</Label>
+            <div className="relative">
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                placeholder="Confirm your new password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                disabled={isLoading}
+                minLength={8}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                disabled={isLoading}
+              >
+                {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+            {confirmPassword && password !== confirmPassword && (
+              <p className="text-xs text-destructive">Passwords do not match</p>
+            )}
+          </div>
+          {error && <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">{error}</div>}
+          <Button type="submit" className="w-full" disabled={isLoading || password !== confirmPassword}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Resetting password...
+              </>
+            ) : (
+              "Reset password"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+      <CardFooter className="flex justify-center">
+        <Button variant="link" className="p-0 h-auto font-normal" asChild>
+          <Link href="/login">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to login
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -77,6 +77,51 @@ export const auth = betterAuth({
         `,
       });
     },
+    async sendResetPassword({
+      user,
+      url,
+    }: {
+      user: { email: string; name?: string | null };
+      url: string;
+    }) {
+      await resend.emails.send({
+        from: "Nuclom <no-reply@nuclom.com>",
+        to: user.email,
+        subject: "Reset your Nuclom password",
+        html: `
+          <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="text-align: center; margin-bottom: 30px;">
+              <h1 style="color: #1a1a1a; font-size: 24px; margin: 0;">Nuclom</h1>
+            </div>
+            <div style="background: #ffffff; border: 1px solid #e5e5e5; border-radius: 8px; padding: 40px;">
+              <h2 style="color: #1a1a1a; font-size: 20px; margin: 0 0 16px;">Reset Your Password</h2>
+              <p style="color: #666666; font-size: 16px; line-height: 24px; margin: 0 0 24px;">
+                Hi ${user.name || "there"},
+              </p>
+              <p style="color: #666666; font-size: 16px; line-height: 24px; margin: 0 0 24px;">
+                We received a request to reset your password. Click the button below to choose a new password.
+              </p>
+              <div style="text-align: center; margin: 32px 0;">
+                <a href="${url}" style="background-color: #000000; color: #ffffff; padding: 12px 32px; text-decoration: none; border-radius: 6px; font-weight: 500; display: inline-block;">
+                  Reset Password
+                </a>
+              </div>
+              <p style="color: #666666; font-size: 14px; line-height: 20px; margin: 24px 0 0;">
+                If you didn't request a password reset, you can safely ignore this email. Your password will remain unchanged.
+              </p>
+              <p style="color: #999999; font-size: 12px; line-height: 18px; margin: 24px 0 0;">
+                This link will expire in 1 hour.
+              </p>
+              <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+              <p style="color: #999999; font-size: 12px; line-height: 18px; margin: 0;">
+                If the button doesn't work, copy and paste this link into your browser:<br />
+                <a href="${url}" style="color: #666666; word-break: break-all;">${url}</a>
+              </p>
+            </div>
+          </div>
+        `,
+      });
+    },
   },
   socialProviders: {
     github: {


### PR DESCRIPTION
- Add forgot-password page with email validation and success state
- Add reset-password page with password strength indicator and token validation
- Add sendResetPassword email handler in auth.ts with styled email template
- Add forgot password link to login form
- Create invitations API route to fetch invitation details
- Add accept-invitation page handling all states (expired, wrong account, etc.)
- Update register form to prefill email from query params for invitation flow
- Update verification pending redirect to preserve redirect URL