### PR TITLE
Debug slow lefthook precommit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,9 +2,9 @@
 # https://github.com/evilmartians/lefthook
 
 pre-commit:
-  parallel: false
+  parallel: true
   commands:
     lint:
       glob: "*.{js,jsx,ts,tsx}"
-      run: pnpm lint:fix
+      run: pnpm biome check --write {staged_files}
       stage_fixed: true


### PR DESCRIPTION
The hook was running `biome check . --write` on the entire project instead of just the staged files. Changed to use lefthook's {staged_files} placeholder for significantly faster commits.