### PR TITLE
Add TypeScript check to pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,3 +8,6 @@ pre-commit:
       glob: "*.{js,jsx,ts,tsx}"
       run: pnpm biome check --write {staged_files}
       stage_fixed: true
+    tsc:
+      glob: "*.{ts,tsx}"
+      run: pnpm tsc


### PR DESCRIPTION
Runs pnpm tsc in parallel with the existing lint command to catch TypeScript errors before commits.