### PR TITLE
Migrate AI features to Vercel gateway

### DIFF
--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -12,6 +12,7 @@ export const ServerEnv = Schema.Struct({
   }),
   DATABASE_URL: Schema.String,
   OPENAI_API_KEY: Schema.optional(Schema.String),
+  REPLICATE_API_TOKEN: Schema.optional(Schema.String),
   VERCEL_OIDC_TOKEN: Schema.optional(Schema.String),
   RESEND_API_KEY: Schema.String,
   RESEND_FROM_EMAIL: Schema.optional(Schema.String),


### PR DESCRIPTION
- Replace direct OpenAI SDK calls with Vercel AI SDK in video-processing workflow
- Use gateway("xai/grok-3") for consistent model routing across the codebase
- Use generateText() and generateObject() with jsonSchema for type-safe outputs
- Keep Whisper transcription using direct OpenAI SDK (not supported by Vercel AI SDK)
- Add documentation comments explaining the transcription approach