### PR TITLE
Add Google Drive integration and bulk video uploads

### DIFF
--- a/src/app/api/integrations/google/drive/route.ts
+++ b/src/app/api/integrations/google/drive/route.ts
@@ -1,0 +1,291 @@
+/**
+ * Google Drive Files API
+ *
+ * Provides endpoints for browsing and importing videos from Google Drive.
+ * This is separate from Meet recordings - allows browsing any video files.
+ */
+
+import { Cause, Effect, Exit, Layer, Option } from "effect";
+import { type NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { NotFoundError, UnauthorizedError } from "@/lib/effect/errors";
+import { DatabaseLive } from "@/lib/effect/services/database";
+import { type GoogleDriveSearchOptions, GoogleMeet, GoogleMeetLive } from "@/lib/effect/services/google-meet";
+import { IntegrationRepository, IntegrationRepositoryLive } from "@/lib/effect/services/integration-repository";
+
+export const dynamic = "force-dynamic";
+
+const IntegrationRepositoryWithDeps = IntegrationRepositoryLive.pipe(Layer.provide(DatabaseLive));
+const DriveLayer = Layer.mergeAll(IntegrationRepositoryWithDeps, DatabaseLive, GoogleMeetLive);
+
+// =============================================================================
+// GET /api/integrations/google/drive - List videos and folders from Google Drive
+// =============================================================================
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+
+  // Query parameters
+  const action = searchParams.get("action") || "list"; // list, search, folders
+  const folderId = searchParams.get("folderId") || undefined;
+  const query = searchParams.get("query") || undefined;
+  const pageSizeParam = searchParams.get("pageSize");
+  const pageSize = pageSizeParam ? Number.parseInt(pageSizeParam, 10) : 50;
+  const pageToken = searchParams.get("pageToken") || undefined;
+  const orderBy = (searchParams.get("orderBy") as GoogleDriveSearchOptions["orderBy"]) || "modifiedTime";
+  const orderDirection = (searchParams.get("orderDirection") as GoogleDriveSearchOptions["orderDirection"]) || "desc";
+
+  // Verify authentication
+  const session = await auth.api.getSession({
+    headers: request.headers,
+  });
+
+  if (!session?.user) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const effect = Effect.gen(function* () {
+    const integrationRepo = yield* IntegrationRepository;
+    const google = yield* GoogleMeet;
+
+    // Check if Google integration is configured
+    if (!google.isConfigured) {
+      return yield* Effect.fail(
+        new NotFoundError({
+          message: "Google integration is not configured",
+          entity: "Integration",
+        }),
+      );
+    }
+
+    // Get user's Google integration
+    const integration = yield* integrationRepo.getIntegrationByProvider(session.user.id, "google_meet");
+
+    if (!integration) {
+      return yield* Effect.fail(
+        new NotFoundError({
+          message: "Google account not connected. Please connect your Google account first.",
+          entity: "Integration",
+        }),
+      );
+    }
+
+    // Check if token is expired and refresh if needed
+    let accessToken = integration.accessToken;
+    if (integration.expiresAt && new Date(integration.expiresAt) < new Date()) {
+      if (!integration.refreshToken) {
+        return yield* Effect.fail(
+          new UnauthorizedError({
+            message: "Access token expired. Please reconnect your Google account.",
+          }),
+        );
+      }
+
+      const newTokens = yield* google.refreshAccessToken(integration.refreshToken);
+      accessToken = newTokens.access_token;
+
+      yield* integrationRepo.updateIntegration(integration.id, {
+        accessToken: newTokens.access_token,
+        refreshToken: newTokens.refresh_token || integration.refreshToken,
+        expiresAt: new Date(Date.now() + newTokens.expires_in * 1000),
+      });
+    }
+
+    // Handle different actions
+    switch (action) {
+      case "search": {
+        if (!query) {
+          return { files: [], folders: [], nextPageToken: undefined };
+        }
+        const searchResult = yield* google.searchVideos(accessToken, query, pageSize, pageToken);
+        return {
+          files: searchResult.files,
+          folders: [],
+          nextPageToken: searchResult.nextPageToken,
+        };
+      }
+
+      case "folders": {
+        const foldersResult = yield* google.listFolders(accessToken, folderId, pageSize, pageToken);
+        return {
+          files: [],
+          folders: foldersResult.folders,
+          nextPageToken: foldersResult.nextPageToken,
+        };
+      }
+
+      default: {
+        // List both folders and files in the current directory (action "list" or any other)
+        const [filesResult, foldersResult] = yield* Effect.all([
+          google.listVideoFiles(accessToken, {
+            folderId,
+            pageSize,
+            pageToken,
+            orderBy,
+            orderDirection,
+          }),
+          google.listFolders(accessToken, folderId, 100),
+        ]);
+
+        return {
+          files: filesResult.files,
+          folders: foldersResult.folders,
+          nextPageToken: filesResult.nextPageToken,
+          currentFolderId: folderId || "root",
+        };
+      }
+    }
+  });
+
+  const exit = await Effect.runPromiseExit(Effect.provide(effect, DriveLayer));
+
+  return Exit.match(exit, {
+    onFailure: (cause) => {
+      const error = Cause.failureOption(cause);
+      if (Option.isSome(error)) {
+        const err = error.value;
+        if (err instanceof NotFoundError) {
+          return NextResponse.json({ success: false, error: err.message }, { status: 404 });
+        }
+        if (err instanceof UnauthorizedError) {
+          return NextResponse.json({ success: false, error: err.message }, { status: 401 });
+        }
+      }
+      console.error("[Google Drive API Error]", cause);
+      return NextResponse.json({ success: false, error: "Failed to fetch Google Drive files" }, { status: 500 });
+    },
+    onSuccess: (data) => {
+      return NextResponse.json({ success: true, data });
+    },
+  });
+}
+
+// =============================================================================
+// POST /api/integrations/google/drive - Import videos from Google Drive
+// =============================================================================
+
+interface ImportDriveVideosRequest {
+  files: Array<{
+    fileId: string;
+    name: string;
+    size: number;
+  }>;
+}
+
+export async function POST(request: NextRequest) {
+  // Verify authentication
+  const session = await auth.api.getSession({
+    headers: request.headers,
+  });
+
+  if (!session?.user) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: ImportDriveVideosRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { files } = body;
+
+  if (!files || !Array.isArray(files) || files.length === 0) {
+    return NextResponse.json({ success: false, error: "No files to import" }, { status: 400 });
+  }
+
+  // Limit to 20 files at a time
+  if (files.length > 20) {
+    return NextResponse.json({ success: false, error: "Maximum 20 files can be imported at once" }, { status: 400 });
+  }
+
+  const effect = Effect.gen(function* () {
+    const integrationRepo = yield* IntegrationRepository;
+    const google = yield* GoogleMeet;
+
+    // Check if Google integration is configured
+    if (!google.isConfigured) {
+      return yield* Effect.fail(
+        new NotFoundError({
+          message: "Google integration is not configured",
+          entity: "Integration",
+        }),
+      );
+    }
+
+    // Get user's Google integration
+    const integration = yield* integrationRepo.getIntegrationByProvider(session.user.id, "google_meet");
+
+    if (!integration) {
+      return yield* Effect.fail(
+        new NotFoundError({
+          message: "Google account not connected",
+          entity: "Integration",
+        }),
+      );
+    }
+
+    // Check if token is expired and refresh if needed
+    let accessToken = integration.accessToken;
+    if (integration.expiresAt && new Date(integration.expiresAt) < new Date()) {
+      if (!integration.refreshToken) {
+        return yield* Effect.fail(
+          new UnauthorizedError({
+            message: "Access token expired. Please reconnect your Google account.",
+          }),
+        );
+      }
+
+      const newTokens = yield* google.refreshAccessToken(integration.refreshToken);
+      accessToken = newTokens.access_token;
+
+      yield* integrationRepo.updateIntegration(integration.id, {
+        accessToken: newTokens.access_token,
+        refreshToken: newTokens.refresh_token || integration.refreshToken,
+        expiresAt: new Date(Date.now() + newTokens.expires_in * 1000),
+      });
+    }
+
+    // Prepare recordings for import using existing import workflow
+    const recordings = files.map((file) => ({
+      externalId: file.fileId,
+      downloadUrl: `https://www.googleapis.com/drive/v3/files/${file.fileId}?alt=media`,
+      title: file.name.replace(/\.[^/.]+$/, ""), // Remove extension for title
+      fileSize: file.size,
+      meetingDate: undefined,
+      duration: undefined,
+    }));
+
+    // Return the prepared recordings to be used with the existing import API
+    return {
+      provider: "google_meet" as const,
+      recordings,
+      integrationId: integration.id,
+      accessToken,
+    };
+  });
+
+  const exit = await Effect.runPromiseExit(Effect.provide(effect, DriveLayer));
+
+  return Exit.match(exit, {
+    onFailure: (cause) => {
+      const error = Cause.failureOption(cause);
+      if (Option.isSome(error)) {
+        const err = error.value;
+        if (err instanceof NotFoundError) {
+          return NextResponse.json({ success: false, error: err.message }, { status: 404 });
+        }
+        if (err instanceof UnauthorizedError) {
+          return NextResponse.json({ success: false, error: err.message }, { status: 401 });
+        }
+      }
+      console.error("[Google Drive Import Error]", cause);
+      return NextResponse.json({ success: false, error: "Failed to prepare import" }, { status: 500 });
+    },
+    onSuccess: (data) => {
+      return NextResponse.json({ success: true, data });
+    },
+  });
+}

--- a/src/app/api/videos/upload/confirm/route.ts
+++ b/src/app/api/videos/upload/confirm/route.ts
@@ -1,0 +1,297 @@
+/**
+ * Upload Confirmation API
+ *
+ * Called after a file has been uploaded directly to R2 via presigned URL.
+ * Creates the video record in the database and triggers processing.
+ */
+
+import { Effect } from "effect";
+import { type NextRequest, NextResponse } from "next/server";
+import { createPublicLayer, mapErrorToApiResponse } from "@/lib/api-handler";
+import { auth } from "@/lib/auth";
+import { Storage, ValidationError, VideoRepository } from "@/lib/effect";
+import type { ApiResponse } from "@/lib/types";
+import { sanitizeDescription, sanitizeTitle } from "@/lib/validation";
+import { processVideoWorkflow } from "@/workflows/video-processing";
+
+export const dynamic = "force-dynamic";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ConfirmUploadRequest {
+  uploadId: string;
+  fileKey: string;
+  filename: string;
+  fileSize: number;
+  title: string;
+  description?: string;
+  organizationId: string;
+  authorId: string;
+  channelId?: string;
+  collectionId?: string;
+  skipAIProcessing?: boolean;
+}
+
+interface BulkConfirmUploadRequest {
+  uploads: Array<{
+    uploadId: string;
+    fileKey: string;
+    filename: string;
+    fileSize: number;
+    title: string;
+    description?: string;
+  }>;
+  organizationId: string;
+  authorId: string;
+  channelId?: string;
+  collectionId?: string;
+  skipAIProcessing?: boolean;
+}
+
+interface ConfirmUploadResponse {
+  videoId: string;
+  videoUrl: string;
+  thumbnailUrl: string;
+  processingStatus: string;
+}
+
+interface BulkConfirmUploadResponse {
+  videos: Array<{
+    uploadId: string;
+    videoId: string;
+    videoUrl: string;
+    processingStatus: string;
+  }>;
+  succeeded: number;
+  failed: number;
+}
+
+// Estimated duration for videos (will be updated during processing)
+const PLACEHOLDER_DURATION = "0:00";
+
+// =============================================================================
+// POST /api/videos/upload/confirm - Confirm upload and create video record
+// =============================================================================
+
+export async function POST(request: NextRequest) {
+  // Verify authentication
+  const session = await auth.api.getSession({
+    headers: request.headers,
+  });
+
+  if (!session?.user) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: ConfirmUploadRequest | BulkConfirmUploadRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 });
+  }
+
+  // Determine if this is a bulk or single confirmation request
+  const isBulkRequest = "uploads" in body && Array.isArray(body.uploads);
+
+  if (isBulkRequest) {
+    return handleBulkConfirmation(body as BulkConfirmUploadRequest);
+  }
+  return handleSingleConfirmation(body as ConfirmUploadRequest);
+}
+
+async function handleSingleConfirmation(body: ConfirmUploadRequest) {
+  const {
+    uploadId,
+    fileKey,
+    filename,
+    fileSize: _fileSize, // Used for tracking, not directly in this function
+    title,
+    description,
+    organizationId,
+    authorId,
+    channelId,
+    collectionId,
+    skipAIProcessing,
+  } = body;
+
+  // Validate required fields
+  if (!uploadId || !fileKey || !filename || !title || !organizationId || !authorId) {
+    return NextResponse.json({ success: false, error: "Missing required fields" }, { status: 400 });
+  }
+
+  const effect = Effect.gen(function* () {
+    const storage = yield* Storage;
+    const videoRepo = yield* VideoRepository;
+
+    // Check if storage is configured
+    if (!storage.isConfigured) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: "Storage is not configured",
+        }),
+      );
+    }
+
+    // Get the public URL for the uploaded file
+    const videoUrl = storage.getPublicUrl(fileKey);
+
+    // Sanitize user input
+    const sanitizedTitle = sanitizeTitle(title);
+    const sanitizedDescription = description ? sanitizeDescription(description) : undefined;
+
+    // Create video record in database
+    const video = yield* videoRepo.createVideo({
+      title: sanitizedTitle,
+      description: sanitizedDescription,
+      duration: PLACEHOLDER_DURATION,
+      videoUrl,
+      thumbnailUrl: undefined, // Will be generated during processing
+      authorId,
+      organizationId,
+      channelId: channelId || undefined,
+      collectionId: collectionId || undefined,
+      processingStatus: skipAIProcessing ? "completed" : "pending",
+    });
+
+    return {
+      videoId: video.id,
+      videoUrl,
+      thumbnailUrl: "",
+      processingStatus: video.processingStatus,
+      skipAIProcessing: skipAIProcessing ?? false,
+      videoTitle: sanitizedTitle,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createPublicLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+
+  if (exit._tag === "Failure") {
+    return mapErrorToApiResponse(exit.cause);
+  }
+
+  const data = exit.value;
+
+  // Trigger AI processing using durable workflow
+  if (!data.skipAIProcessing && data.videoUrl) {
+    processVideoWorkflow({
+      videoId: data.videoId,
+      videoUrl: data.videoUrl,
+      videoTitle: data.videoTitle,
+    }).catch((err) => {
+      console.error("[Video Processing Workflow Error]", err);
+    });
+  }
+
+  const response: ApiResponse<ConfirmUploadResponse> = {
+    success: true,
+    data: {
+      videoId: data.videoId,
+      videoUrl: data.videoUrl,
+      thumbnailUrl: data.thumbnailUrl,
+      processingStatus: data.processingStatus,
+    },
+  };
+
+  return NextResponse.json(response, { status: 201 });
+}
+
+async function handleBulkConfirmation(body: BulkConfirmUploadRequest) {
+  const { uploads, organizationId, authorId, channelId, collectionId, skipAIProcessing } = body;
+
+  // Validate required fields
+  if (!uploads || uploads.length === 0 || !organizationId || !authorId) {
+    return NextResponse.json({ success: false, error: "Missing required fields" }, { status: 400 });
+  }
+
+  // Validate each upload
+  for (const upload of uploads) {
+    if (!upload.uploadId || !upload.fileKey || !upload.filename || !upload.title) {
+      return NextResponse.json(
+        { success: false, error: "Each upload must have uploadId, fileKey, filename, and title" },
+        { status: 400 },
+      );
+    }
+  }
+
+  const effect = Effect.gen(function* () {
+    const storage = yield* Storage;
+    const videoRepo = yield* VideoRepository;
+
+    // Check if storage is configured
+    if (!storage.isConfigured) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: "Storage is not configured",
+        }),
+      );
+    }
+
+    const results: BulkConfirmUploadResponse["videos"] = [];
+    let succeeded = 0;
+    let failed = 0;
+
+    for (const upload of uploads) {
+      try {
+        const videoUrl = storage.getPublicUrl(upload.fileKey);
+        const sanitizedTitle = sanitizeTitle(upload.title);
+        const sanitizedDescription = upload.description ? sanitizeDescription(upload.description) : undefined;
+
+        const video = yield* videoRepo.createVideo({
+          title: sanitizedTitle,
+          description: sanitizedDescription,
+          duration: PLACEHOLDER_DURATION,
+          videoUrl,
+          thumbnailUrl: undefined,
+          authorId,
+          organizationId,
+          channelId: channelId || undefined,
+          collectionId: collectionId || undefined,
+          processingStatus: skipAIProcessing ? "completed" : "pending",
+        });
+
+        results.push({
+          uploadId: upload.uploadId,
+          videoId: video.id,
+          videoUrl,
+          processingStatus: video.processingStatus,
+        });
+
+        // Trigger processing for each video
+        if (!skipAIProcessing) {
+          processVideoWorkflow({
+            videoId: video.id,
+            videoUrl,
+            videoTitle: sanitizedTitle,
+          }).catch((err) => {
+            console.error(`[Video Processing Workflow Error for ${video.id}]`, err);
+          });
+        }
+
+        succeeded++;
+      } catch (err) {
+        console.error(`[Bulk Confirm Error for ${upload.uploadId}]`, err);
+        failed++;
+      }
+    }
+
+    return { videos: results, succeeded, failed };
+  });
+
+  const runnable = Effect.provide(effect, createPublicLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+
+  if (exit._tag === "Failure") {
+    return mapErrorToApiResponse(exit.cause);
+  }
+
+  const response: ApiResponse<BulkConfirmUploadResponse> = {
+    success: true,
+    data: exit.value,
+  };
+
+  return NextResponse.json(response, { status: 201 });
+}

--- a/src/app/api/videos/upload/presigned/route.ts
+++ b/src/app/api/videos/upload/presigned/route.ts
@@ -1,0 +1,287 @@
+/**
+ * Presigned URL Upload API
+ *
+ * Generates presigned URLs for direct-to-R2 uploads, bypassing Vercel API route size limits.
+ * This enables uploading videos of any size directly from the browser to cloud storage.
+ */
+
+import { Effect, Option } from "effect";
+import { type NextRequest, NextResponse } from "next/server";
+import { createPublicLayer, mapErrorToApiResponse } from "@/lib/api-handler";
+import { auth } from "@/lib/auth";
+import { Storage, ValidationError } from "@/lib/effect";
+import { trackVideoUpload } from "@/lib/effect/services/billing-middleware";
+import { BillingRepository } from "@/lib/effect/services/billing-repository";
+import type { ApiResponse } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface PresignedUploadRequest {
+  filename: string;
+  contentType: string;
+  fileSize: number;
+  organizationId: string;
+}
+
+interface PresignedUploadResponse {
+  uploadId: string;
+  uploadUrl: string;
+  fileKey: string;
+  expiresIn: number;
+}
+
+interface BulkPresignedUploadRequest {
+  files: Array<{
+    filename: string;
+    contentType: string;
+    fileSize: number;
+  }>;
+  organizationId: string;
+}
+
+interface BulkPresignedUploadResponse {
+  uploads: Array<{
+    uploadId: string;
+    uploadUrl: string;
+    fileKey: string;
+    filename: string;
+    expiresIn: number;
+  }>;
+}
+
+// Supported video MIME types
+const SUPPORTED_VIDEO_TYPES = [
+  "video/mp4",
+  "video/quicktime",
+  "video/x-msvideo",
+  "video/x-matroska",
+  "video/webm",
+  "video/x-flv",
+  "video/x-ms-wmv",
+  "video/3gpp",
+  "video/mpeg",
+  "video/ogg",
+];
+
+// Maximum file size: 5GB (Cloudflare R2 supports up to 5TB, but we limit for practical reasons)
+const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
+
+// Presigned URL expiration: 1 hour
+const PRESIGNED_URL_EXPIRATION = 3600;
+
+// =============================================================================
+// POST /api/videos/upload/presigned - Generate presigned upload URL(s)
+// =============================================================================
+
+export async function POST(request: NextRequest) {
+  // Verify authentication
+  const session = await auth.api.getSession({
+    headers: request.headers,
+  });
+
+  if (!session?.user) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: PresignedUploadRequest | BulkPresignedUploadRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 });
+  }
+
+  // Determine if this is a bulk or single upload request
+  const isBulkRequest = "files" in body && Array.isArray(body.files);
+
+  if (isBulkRequest) {
+    return handleBulkPresignedUpload(body as BulkPresignedUploadRequest, session.user.id);
+  }
+  return handleSinglePresignedUpload(body as PresignedUploadRequest, session.user.id);
+}
+
+async function handleSinglePresignedUpload(body: PresignedUploadRequest, _userId: string) {
+  const { filename, contentType, fileSize, organizationId } = body;
+
+  // Validate request
+  if (!filename || !contentType || !fileSize || !organizationId) {
+    return NextResponse.json(
+      { success: false, error: "Missing required fields: filename, contentType, fileSize, organizationId" },
+      { status: 400 },
+    );
+  }
+
+  // Validate content type
+  if (!SUPPORTED_VIDEO_TYPES.includes(contentType)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Unsupported content type: ${contentType}. Supported types: ${SUPPORTED_VIDEO_TYPES.join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Validate file size
+  if (fileSize > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { success: false, error: `File size exceeds maximum allowed: ${MAX_FILE_SIZE / (1024 * 1024 * 1024)}GB` },
+      { status: 400 },
+    );
+  }
+
+  const effect = Effect.gen(function* () {
+    const storage = yield* Storage;
+
+    // Check if storage is configured
+    if (!storage.isConfigured) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: "Storage is not configured",
+        }),
+      );
+    }
+
+    // Check plan limits before generating presigned URL
+    const billingRepo = yield* BillingRepository;
+    const subscriptionOption = yield* billingRepo.getSubscriptionOption(organizationId);
+
+    if (Option.isSome(subscriptionOption)) {
+      // Track the upload (this will check limits)
+      yield* trackVideoUpload(organizationId, fileSize);
+    }
+
+    // Generate unique file key
+    const fileKey = storage.generateFileKey(organizationId, filename, "video");
+
+    // Generate presigned upload URL
+    const uploadUrl = yield* storage.generatePresignedUploadUrl(fileKey, contentType, PRESIGNED_URL_EXPIRATION);
+
+    // Generate a unique upload ID for tracking
+    const uploadId = crypto.randomUUID();
+
+    return {
+      uploadId,
+      uploadUrl,
+      fileKey,
+      expiresIn: PRESIGNED_URL_EXPIRATION,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createPublicLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+
+  if (exit._tag === "Failure") {
+    return mapErrorToApiResponse(exit.cause);
+  }
+
+  const response: ApiResponse<PresignedUploadResponse> = {
+    success: true,
+    data: exit.value,
+  };
+
+  return NextResponse.json(response, { status: 200 });
+}
+
+async function handleBulkPresignedUpload(body: BulkPresignedUploadRequest, _userId: string) {
+  const { files, organizationId } = body;
+
+  // Validate request
+  if (!files || files.length === 0 || !organizationId) {
+    return NextResponse.json(
+      { success: false, error: "Missing required fields: files, organizationId" },
+      { status: 400 },
+    );
+  }
+
+  // Validate each file
+  for (const file of files) {
+    if (!file.filename || !file.contentType || !file.fileSize) {
+      return NextResponse.json(
+        { success: false, error: "Each file must have filename, contentType, and fileSize" },
+        { status: 400 },
+      );
+    }
+
+    if (!SUPPORTED_VIDEO_TYPES.includes(file.contentType)) {
+      return NextResponse.json(
+        { success: false, error: `Unsupported content type for ${file.filename}: ${file.contentType}` },
+        { status: 400 },
+      );
+    }
+
+    if (file.fileSize > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `File ${file.filename} exceeds maximum size of ${MAX_FILE_SIZE / (1024 * 1024 * 1024)}GB`,
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Limit bulk uploads to 20 files at a time
+  if (files.length > 20) {
+    return NextResponse.json({ success: false, error: "Maximum 20 files can be uploaded at once" }, { status: 400 });
+  }
+
+  const effect = Effect.gen(function* () {
+    const storage = yield* Storage;
+
+    // Check if storage is configured
+    if (!storage.isConfigured) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: "Storage is not configured",
+        }),
+      );
+    }
+
+    // Check plan limits for total upload size
+    const totalSize = files.reduce((sum, f) => sum + f.fileSize, 0);
+    const billingRepo = yield* BillingRepository;
+    const subscriptionOption = yield* billingRepo.getSubscriptionOption(organizationId);
+
+    if (Option.isSome(subscriptionOption)) {
+      yield* trackVideoUpload(organizationId, totalSize);
+    }
+
+    // Generate presigned URLs for each file
+    const uploads: BulkPresignedUploadResponse["uploads"] = [];
+
+    for (const file of files) {
+      const fileKey = storage.generateFileKey(organizationId, file.filename, "video");
+      const uploadUrl = yield* storage.generatePresignedUploadUrl(fileKey, file.contentType, PRESIGNED_URL_EXPIRATION);
+      const uploadId = crypto.randomUUID();
+
+      uploads.push({
+        uploadId,
+        uploadUrl,
+        fileKey,
+        filename: file.filename,
+        expiresIn: PRESIGNED_URL_EXPIRATION,
+      });
+    }
+
+    return { uploads };
+  });
+
+  const runnable = Effect.provide(effect, createPublicLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+
+  if (exit._tag === "Failure") {
+    return mapErrorToApiResponse(exit.cause);
+  }
+
+  const response: ApiResponse<BulkPresignedUploadResponse> = {
+    success: true,
+    data: exit.value,
+  };
+
+  return NextResponse.json(response, { status: 200 });
+}

--- a/src/components/bulk-video-upload.tsx
+++ b/src/components/bulk-video-upload.tsx
@@ -1,0 +1,617 @@
+"use client";
+
+import { AlertCircle, CheckCircle, ChevronDown, ChevronUp, FileVideo, Loader2, Trash2, Upload } from "lucide-react";
+import { type ChangeEvent, useCallback, useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useToast } from "@/hooks/use-toast";
+import { formatFileSize } from "@/lib/format-utils";
+import { cn } from "@/lib/utils";
+
+interface BulkVideoUploadProps {
+  organizationId: string;
+  authorId: string;
+  channelId?: string;
+  collectionId?: string;
+  onUploadComplete?: (results: Array<{ videoId: string; title: string }>) => void;
+  onCancel?: () => void;
+}
+
+interface FileUpload {
+  id: string;
+  file: File;
+  title: string;
+  status: "pending" | "preparing" | "uploading" | "confirming" | "completed" | "failed" | "paused";
+  progress: number;
+  error?: string;
+  uploadUrl?: string;
+  fileKey?: string;
+  videoId?: string;
+  abortController?: AbortController;
+}
+
+// Supported video MIME types
+const SUPPORTED_VIDEO_TYPES = [
+  "video/mp4",
+  "video/quicktime",
+  "video/x-msvideo",
+  "video/x-matroska",
+  "video/webm",
+  "video/x-flv",
+  "video/x-ms-wmv",
+  "video/3gpp",
+  "video/mpeg",
+  "video/ogg",
+];
+
+// Max file size: 5GB
+const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
+
+// Max files at once
+const MAX_FILES = 20;
+
+// Concurrent uploads
+const CONCURRENT_UPLOADS = 3;
+
+export function BulkVideoUpload({
+  organizationId,
+  authorId,
+  channelId,
+  collectionId,
+  onUploadComplete,
+  onCancel,
+}: BulkVideoUploadProps) {
+  const { toast } = useToast();
+  const [uploads, setUploads] = useState<FileUpload[]>([]);
+  const [dragActive, setDragActive] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [showCompleted, setShowCompleted] = useState(true);
+
+  const pendingUploads = uploads.filter((u) => u.status === "pending");
+  const activeUploads = uploads.filter((u) => ["preparing", "uploading", "confirming"].includes(u.status));
+  const completedUploads = uploads.filter((u) => u.status === "completed");
+  const failedUploads = uploads.filter((u) => u.status === "failed");
+
+  const addFiles = useCallback(
+    (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      const validFiles: FileUpload[] = [];
+      const errors: string[] = [];
+
+      // Check total count
+      if (uploads.length + fileArray.length > MAX_FILES) {
+        toast({
+          title: "Too many files",
+          description: `Maximum ${MAX_FILES} files can be uploaded at once. You have ${uploads.length} files already.`,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      for (const file of fileArray) {
+        // Check type
+        if (!SUPPORTED_VIDEO_TYPES.includes(file.type)) {
+          errors.push(`${file.name}: Unsupported format`);
+          continue;
+        }
+
+        // Check size
+        if (file.size > MAX_FILE_SIZE) {
+          errors.push(`${file.name}: Exceeds 5GB limit`);
+          continue;
+        }
+
+        // Check duplicates
+        if (uploads.some((u) => u.file.name === file.name && u.file.size === file.size)) {
+          errors.push(`${file.name}: Already added`);
+          continue;
+        }
+
+        validFiles.push({
+          id: crypto.randomUUID(),
+          file,
+          title: file.name.replace(/\.[^/.]+$/, ""), // Remove extension
+          status: "pending",
+          progress: 0,
+        });
+      }
+
+      if (errors.length > 0) {
+        toast({
+          title: "Some files were skipped",
+          description: errors.slice(0, 3).join(", ") + (errors.length > 3 ? ` and ${errors.length - 3} more` : ""),
+          variant: "destructive",
+        });
+      }
+
+      if (validFiles.length > 0) {
+        setUploads((prev) => [...prev, ...validFiles]);
+      }
+    },
+    [uploads, toast],
+  );
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      addFiles(e.target.files);
+    }
+    // Reset input so same file can be selected again
+    e.target.value = "";
+  };
+
+  const handleDrag = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive(true);
+    } else if (e.type === "dragleave") {
+      setDragActive(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDragActive(false);
+
+      if (e.dataTransfer.files) {
+        addFiles(e.dataTransfer.files);
+      }
+    },
+    [addFiles],
+  );
+
+  const removeUpload = (id: string) => {
+    setUploads((prev) => {
+      const upload = prev.find((u) => u.id === id);
+      if (upload?.abortController) {
+        upload.abortController.abort();
+      }
+      return prev.filter((u) => u.id !== id);
+    });
+  };
+
+  const updateTitle = (id: string, title: string) => {
+    setUploads((prev) => prev.map((u) => (u.id === id ? { ...u, title } : u)));
+  };
+
+  const uploadFile = async (upload: FileUpload): Promise<void> => {
+    const abortController = new AbortController();
+
+    try {
+      // Update status to preparing
+      setUploads((prev) =>
+        prev.map((u) => (u.id === upload.id ? { ...u, status: "preparing" as const, abortController } : u)),
+      );
+
+      // Step 1: Get presigned URL
+      const presignedResponse = await fetch("/api/videos/upload/presigned", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          filename: upload.file.name,
+          contentType: upload.file.type,
+          fileSize: upload.file.size,
+          organizationId,
+        }),
+        signal: abortController.signal,
+      });
+
+      const presignedData = await presignedResponse.json();
+
+      if (!presignedData.success) {
+        throw new Error(presignedData.error || "Failed to get upload URL");
+      }
+
+      const { uploadUrl, fileKey, uploadId } = presignedData.data;
+
+      // Update status to uploading
+      setUploads((prev) =>
+        prev.map((u) =>
+          u.id === upload.id ? { ...u, status: "uploading" as const, uploadUrl, fileKey, progress: 0 } : u,
+        ),
+      );
+
+      // Step 2: Upload directly to R2 using presigned URL
+      const xhr = new XMLHttpRequest();
+
+      await new Promise<void>((resolve, reject) => {
+        xhr.upload.addEventListener("progress", (e) => {
+          if (e.lengthComputable) {
+            const progress = Math.round((e.loaded / e.total) * 100);
+            setUploads((prev) => prev.map((u) => (u.id === upload.id ? { ...u, progress } : u)));
+          }
+        });
+
+        xhr.addEventListener("load", () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve();
+          } else {
+            reject(new Error(`Upload failed with status ${xhr.status}`));
+          }
+        });
+
+        xhr.addEventListener("error", () => reject(new Error("Upload failed")));
+        xhr.addEventListener("abort", () => reject(new Error("Upload aborted")));
+
+        // Handle abort signal
+        abortController.signal.addEventListener("abort", () => xhr.abort());
+
+        xhr.open("PUT", uploadUrl);
+        xhr.setRequestHeader("Content-Type", upload.file.type);
+        xhr.send(upload.file);
+      });
+
+      // Update status to confirming
+      setUploads((prev) =>
+        prev.map((u) => (u.id === upload.id ? { ...u, status: "confirming" as const, progress: 100 } : u)),
+      );
+
+      // Step 3: Confirm upload and create video record
+      const confirmResponse = await fetch("/api/videos/upload/confirm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uploadId,
+          fileKey,
+          filename: upload.file.name,
+          fileSize: upload.file.size,
+          title: upload.title,
+          organizationId,
+          authorId,
+          channelId,
+          collectionId,
+        }),
+        signal: abortController.signal,
+      });
+
+      const confirmData = await confirmResponse.json();
+
+      if (!confirmData.success) {
+        throw new Error(confirmData.error || "Failed to confirm upload");
+      }
+
+      // Update status to completed
+      setUploads((prev) =>
+        prev.map((u) =>
+          u.id === upload.id ? { ...u, status: "completed" as const, videoId: confirmData.data.videoId } : u,
+        ),
+      );
+    } catch (error) {
+      if ((error as Error).name === "AbortError" || (error as Error).message === "Upload aborted") {
+        setUploads((prev) =>
+          prev.map((u) => (u.id === upload.id ? { ...u, status: "pending" as const, progress: 0 } : u)),
+        );
+      } else {
+        setUploads((prev) =>
+          prev.map((u) =>
+            u.id === upload.id
+              ? {
+                  ...u,
+                  status: "failed" as const,
+                  error: error instanceof Error ? error.message : "Upload failed",
+                }
+              : u,
+          ),
+        );
+      }
+    }
+  };
+
+  const startUploads = async () => {
+    if (pendingUploads.length === 0) return;
+
+    setIsUploading(true);
+
+    // Process uploads with concurrency limit
+    const queue = [...pendingUploads];
+
+    const processQueue = async () => {
+      while (queue.length > 0) {
+        const batch = queue.splice(0, CONCURRENT_UPLOADS);
+        await Promise.all(batch.map((upload) => uploadFile(upload)));
+      }
+    };
+
+    await processQueue();
+
+    setIsUploading(false);
+
+    // Get final results
+    const completed = uploads.filter(
+      (u): u is FileUpload & { videoId: string } => u.status === "completed" && u.videoId !== undefined,
+    );
+    if (completed.length > 0 && onUploadComplete) {
+      onUploadComplete(completed.map((u) => ({ videoId: u.videoId, title: u.title })));
+    }
+  };
+
+  const retryFailed = async () => {
+    // Reset failed uploads to pending
+    setUploads((prev) =>
+      prev.map((u) =>
+        u.status === "failed" ? { ...u, status: "pending" as const, error: undefined, progress: 0 } : u,
+      ),
+    );
+
+    // Start uploads
+    await startUploads();
+  };
+
+  const clearCompleted = () => {
+    setUploads((prev) => prev.filter((u) => u.status !== "completed"));
+  };
+
+  const getStatusBadge = (status: FileUpload["status"]) => {
+    switch (status) {
+      case "pending":
+        return <Badge variant="secondary">Pending</Badge>;
+      case "preparing":
+        return (
+          <Badge variant="secondary" className="gap-1">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Preparing
+          </Badge>
+        );
+      case "uploading":
+        return (
+          <Badge variant="default" className="gap-1 bg-blue-500">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Uploading
+          </Badge>
+        );
+      case "confirming":
+        return (
+          <Badge variant="default" className="gap-1 bg-purple-500">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Processing
+          </Badge>
+        );
+      case "completed":
+        return (
+          <Badge variant="default" className="gap-1 bg-green-500">
+            <CheckCircle className="h-3 w-3" />
+            Complete
+          </Badge>
+        );
+      case "failed":
+        return (
+          <Badge variant="destructive" className="gap-1">
+            <AlertCircle className="h-3 w-3" />
+            Failed
+          </Badge>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const totalSize = uploads.reduce((sum, u) => sum + u.file.size, 0);
+  const uploadedSize = uploads.filter((u) => u.status === "completed").reduce((sum, u) => sum + u.file.size, 0);
+
+  return (
+    <Card className="w-full max-w-3xl mx-auto">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Upload className="h-5 w-5" />
+          Bulk Video Upload
+        </CardTitle>
+        <CardDescription>
+          Upload multiple videos at once. Files are uploaded directly to cloud storage for faster, more reliable uploads
+          with no size limits.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Drop Zone */}
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: Drag and drop zone requires event handlers */}
+        <div
+          className={cn(
+            "border-2 border-dashed rounded-lg p-8 text-center transition-colors",
+            dragActive ? "border-primary bg-primary/5" : "border-muted-foreground/25",
+            isUploading && "opacity-50 pointer-events-none",
+          )}
+          onDragEnter={handleDrag}
+          onDragLeave={handleDrag}
+          onDragOver={handleDrag}
+          onDrop={handleDrop}
+        >
+          <div className="space-y-4">
+            <Upload className="h-12 w-12 mx-auto text-muted-foreground" />
+            <div>
+              <p className="text-lg font-medium">Drop your videos here</p>
+              <p className="text-sm text-muted-foreground">or click to select files</p>
+            </div>
+            <Input
+              type="file"
+              accept="video/*"
+              onChange={handleFileChange}
+              multiple
+              className="hidden"
+              id="bulk-video-upload"
+              disabled={isUploading}
+            />
+            <Label htmlFor="bulk-video-upload" className="cursor-pointer">
+              <Button type="button" variant="outline" disabled={isUploading}>
+                Select Video Files
+              </Button>
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              MP4, MOV, AVI, MKV, WebM supported · Up to 5GB per file · Maximum {MAX_FILES} files
+            </p>
+          </div>
+        </div>
+
+        {/* Upload List */}
+        {uploads.length > 0 && (
+          <div className="space-y-4">
+            {/* Summary */}
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>
+                {uploads.length} file{uploads.length !== 1 ? "s" : ""} · {formatFileSize(totalSize)}
+              </span>
+              <div className="flex items-center gap-4">
+                {completedUploads.length > 0 && (
+                  <span className="text-green-600">{completedUploads.length} completed</span>
+                )}
+                {failedUploads.length > 0 && <span className="text-red-600">{failedUploads.length} failed</span>}
+              </div>
+            </div>
+
+            {/* Overall Progress */}
+            {isUploading && (
+              <div className="space-y-2">
+                <Progress value={(uploadedSize / totalSize) * 100} className="h-2" />
+                <p className="text-sm text-muted-foreground text-center">
+                  Uploading {activeUploads.length} of {pendingUploads.length + activeUploads.length} files
+                </p>
+              </div>
+            )}
+
+            {/* File List */}
+            <ScrollArea className="max-h-80">
+              <div className="space-y-2">
+                {uploads.map((upload) => (
+                  <div
+                    key={upload.id}
+                    className={cn(
+                      "flex items-center gap-3 p-3 rounded-lg border",
+                      upload.status === "failed" && "border-destructive/50 bg-destructive/5",
+                      upload.status === "completed" && "border-green-500/50 bg-green-500/5",
+                    )}
+                  >
+                    <FileVideo className="h-8 w-8 text-muted-foreground shrink-0" />
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      {upload.status === "pending" ? (
+                        <Input
+                          value={upload.title}
+                          onChange={(e) => updateTitle(upload.id, e.target.value)}
+                          className="h-7 text-sm"
+                          placeholder="Video title"
+                        />
+                      ) : (
+                        <p className="font-medium truncate text-sm">{upload.title}</p>
+                      )}
+
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{formatFileSize(upload.file.size)}</span>
+                        {upload.status === "uploading" && (
+                          <>
+                            <span>·</span>
+                            <span>{upload.progress}%</span>
+                          </>
+                        )}
+                        {upload.error && (
+                          <>
+                            <span>·</span>
+                            <span className="text-destructive">{upload.error}</span>
+                          </>
+                        )}
+                      </div>
+
+                      {upload.status === "uploading" && <Progress value={upload.progress} className="h-1" />}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      {getStatusBadge(upload.status)}
+
+                      {(upload.status === "pending" || upload.status === "failed") && (
+                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => removeUpload(upload.id)}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+
+            {/* Completed Section Toggle */}
+            {completedUploads.length > 0 && (
+              <Button
+                variant="ghost"
+                className="w-full text-sm text-muted-foreground"
+                onClick={() => setShowCompleted(!showCompleted)}
+              >
+                {showCompleted ? (
+                  <>
+                    <ChevronUp className="h-4 w-4 mr-2" />
+                    Hide completed ({completedUploads.length})
+                  </>
+                ) : (
+                  <>
+                    <ChevronDown className="h-4 w-4 mr-2" />
+                    Show completed ({completedUploads.length})
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Error Alert */}
+        {failedUploads.length > 0 && !isUploading && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex items-center justify-between">
+              <span>
+                {failedUploads.length} upload{failedUploads.length !== 1 ? "s" : ""} failed
+              </span>
+              <Button variant="outline" size="sm" onClick={retryFailed}>
+                Retry Failed
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Success Alert */}
+        {completedUploads.length === uploads.length && uploads.length > 0 && !isUploading && (
+          <Alert>
+            <CheckCircle className="h-4 w-4" />
+            <AlertDescription>
+              All {completedUploads.length} video{completedUploads.length !== 1 ? "s" : ""} uploaded successfully!
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Action Buttons */}
+        <div className="flex gap-2 pt-4">
+          {pendingUploads.length > 0 && (
+            <Button onClick={startUploads} disabled={isUploading} className="flex-1">
+              {isUploading ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Uploading...
+                </>
+              ) : (
+                <>
+                  <Upload className="h-4 w-4 mr-2" />
+                  Upload {pendingUploads.length} Video{pendingUploads.length !== 1 ? "s" : ""}
+                </>
+              )}
+            </Button>
+          )}
+
+          {completedUploads.length > 0 && !isUploading && (
+            <Button variant="outline" onClick={clearCompleted}>
+              Clear Completed
+            </Button>
+          )}
+
+          {onCancel && (
+            <Button variant="outline" onClick={onCancel} disabled={isUploading}>
+              {uploads.length === 0 ? "Cancel" : "Close"}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/import-hub.tsx
+++ b/src/components/import-hub.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { Cloud, FileVideo, HardDrive, Plus, Upload, Video } from "lucide-react";
+import { useState } from "react";
+import { BulkVideoUpload } from "@/components/bulk-video-upload";
+import { GoogleDrivePicker } from "@/components/integrations/google-drive-picker";
+import { RecordingBrowser } from "@/components/integrations/recording-browser";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToast } from "@/hooks/use-toast";
+
+interface ImportHubProps {
+  organizationId: string;
+  organizationSlug: string;
+  authorId: string;
+  channelId?: string;
+  collectionId?: string;
+  onImportComplete?: (count: number) => void;
+}
+
+interface ImportSource {
+  id: string;
+  name: string;
+  description: string;
+  icon: React.ReactNode;
+  available: boolean;
+  comingSoon?: boolean;
+}
+
+export function ImportHub({
+  organizationId,
+  organizationSlug,
+  authorId,
+  channelId,
+  collectionId,
+  onImportComplete,
+}: ImportHubProps) {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("local");
+  const [showZoomBrowser, setShowZoomBrowser] = useState(false);
+  const [showMeetBrowser, setShowMeetBrowser] = useState(false);
+  const [showDrivePicker, setShowDrivePicker] = useState(false);
+
+  const handleBulkUploadComplete = (results: Array<{ videoId: string; title: string }>) => {
+    toast({
+      title: "Videos Uploaded",
+      description: `${results.length} video${results.length !== 1 ? "s" : ""} uploaded successfully.`,
+    });
+    onImportComplete?.(results.length);
+    setOpen(false);
+  };
+
+  const handleGoogleDriveImport = async (files: Array<{ id: string; name: string; size: number }>) => {
+    // Use the existing import API
+    const response = await fetch("/api/integrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider: "google_meet",
+        recordings: files.map((f) => ({
+          externalId: f.id,
+          downloadUrl: `https://www.googleapis.com/drive/v3/files/${f.id}?alt=media`,
+          title: f.name.replace(/\.[^/.]+$/, ""),
+          fileSize: f.size,
+        })),
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!data.success) {
+      throw new Error(data.error || "Import failed");
+    }
+
+    onImportComplete?.(data.data.imported);
+    setShowDrivePicker(false);
+    setOpen(false);
+  };
+
+  const importSources: ImportSource[] = [
+    {
+      id: "local",
+      name: "Local Files",
+      description: "Upload video files from your computer",
+      icon: <Upload className="h-6 w-6" />,
+      available: true,
+    },
+    {
+      id: "google-drive",
+      name: "Google Drive",
+      description: "Import videos stored in Google Drive",
+      icon: <HardDrive className="h-6 w-6" />,
+      available: true,
+    },
+    {
+      id: "google-meet",
+      name: "Google Meet",
+      description: "Import recordings from Google Meet",
+      icon: <Video className="h-6 w-6" />,
+      available: true,
+    },
+    {
+      id: "zoom",
+      name: "Zoom",
+      description: "Import recordings from Zoom meetings",
+      icon: <Video className="h-6 w-6" />,
+      available: true,
+    },
+    {
+      id: "dropbox",
+      name: "Dropbox",
+      description: "Import videos from Dropbox",
+      icon: <Cloud className="h-6 w-6" />,
+      available: false,
+      comingSoon: true,
+    },
+    {
+      id: "onedrive",
+      name: "OneDrive",
+      description: "Import videos from Microsoft OneDrive",
+      icon: <Cloud className="h-6 w-6" />,
+      available: false,
+      comingSoon: true,
+    },
+  ];
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button className="gap-2">
+            <Plus className="h-4 w-4" />
+            Import Videos
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <FileVideo className="h-5 w-5" />
+              Import Videos
+            </DialogTitle>
+            <DialogDescription>
+              Choose a source to import videos from. You can upload local files or import from connected services.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+            <TabsList className="grid w-full grid-cols-2 mb-4">
+              <TabsTrigger value="local" className="gap-2">
+                <Upload className="h-4 w-4" />
+                Upload Files
+              </TabsTrigger>
+              <TabsTrigger value="sources" className="gap-2">
+                <Cloud className="h-4 w-4" />
+                Import Sources
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="local" className="mt-0">
+              <BulkVideoUpload
+                organizationId={organizationId}
+                authorId={authorId}
+                channelId={channelId}
+                collectionId={collectionId}
+                onUploadComplete={handleBulkUploadComplete}
+                onCancel={() => setOpen(false)}
+              />
+            </TabsContent>
+
+            <TabsContent value="sources" className="mt-0">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {importSources
+                  .filter((s) => s.id !== "local")
+                  .map((source) => (
+                    <Card
+                      key={source.id}
+                      className={`cursor-pointer transition-all hover:shadow-md ${
+                        source.available ? "hover:border-primary" : "opacity-60 cursor-not-allowed"
+                      }`}
+                      onClick={() => {
+                        if (!source.available) return;
+                        switch (source.id) {
+                          case "google-drive":
+                            setShowDrivePicker(true);
+                            break;
+                          case "google-meet":
+                            setShowMeetBrowser(true);
+                            break;
+                          case "zoom":
+                            setShowZoomBrowser(true);
+                            break;
+                        }
+                      }}
+                    >
+                      <CardHeader className="pb-2">
+                        <div className="flex items-center justify-between">
+                          <div className="p-2 rounded-lg bg-muted text-muted-foreground">{source.icon}</div>
+                          {source.comingSoon && (
+                            <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
+                              Coming Soon
+                            </span>
+                          )}
+                        </div>
+                      </CardHeader>
+                      <CardContent>
+                        <CardTitle className="text-base mb-1">{source.name}</CardTitle>
+                        <CardDescription className="text-sm">{source.description}</CardDescription>
+                      </CardContent>
+                    </Card>
+                  ))}
+              </div>
+
+              {/* Quick Actions */}
+              <div className="mt-6 pt-6 border-t">
+                <h3 className="text-sm font-medium mb-3">Quick Actions</h3>
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="outline" size="sm" className="gap-2" onClick={() => setShowDrivePicker(true)}>
+                    <HardDrive className="h-4 w-4" />
+                    Browse Google Drive
+                  </Button>
+                  <Button variant="outline" size="sm" className="gap-2" onClick={() => setShowMeetBrowser(true)}>
+                    <Video className="h-4 w-4" />
+                    Import from Meet
+                  </Button>
+                  <Button variant="outline" size="sm" className="gap-2" onClick={() => setShowZoomBrowser(true)}>
+                    <Video className="h-4 w-4" />
+                    Import from Zoom
+                  </Button>
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </DialogContent>
+      </Dialog>
+
+      {/* Recording Browsers */}
+      <RecordingBrowser
+        provider="zoom"
+        open={showZoomBrowser}
+        onClose={() => setShowZoomBrowser(false)}
+        organizationSlug={organizationSlug}
+      />
+
+      <RecordingBrowser
+        provider="google_meet"
+        open={showMeetBrowser}
+        onClose={() => setShowMeetBrowser(false)}
+        organizationSlug={organizationSlug}
+      />
+
+      {/* Google Drive Picker */}
+      <GoogleDrivePicker
+        open={showDrivePicker}
+        onClose={() => setShowDrivePicker(false)}
+        onImport={handleGoogleDriveImport}
+      />
+    </>
+  );
+}
+
+// Standalone Import Button for simpler use cases
+interface ImportButtonProps {
+  organizationId: string;
+  organizationSlug: string;
+  authorId: string;
+  channelId?: string;
+  variant?: "default" | "outline" | "ghost";
+  size?: "default" | "sm" | "lg" | "icon";
+}
+
+export function ImportButton({
+  organizationId,
+  organizationSlug,
+  authorId,
+  channelId,
+  variant: _variant = "default", // Reserved for future use
+  size: _size = "default", // Reserved for future use
+}: ImportButtonProps) {
+  return (
+    <ImportHub
+      organizationId={organizationId}
+      organizationSlug={organizationSlug}
+      authorId={authorId}
+      channelId={channelId}
+    />
+  );
+}

--- a/src/components/integrations/google-drive-picker.tsx
+++ b/src/components/integrations/google-drive-picker.tsx
@@ -1,0 +1,622 @@
+"use client";
+
+import { format, formatDistanceToNow } from "date-fns";
+import {
+  ArrowLeft,
+  Check,
+  ChevronRight,
+  Download,
+  FileVideo,
+  Folder,
+  FolderOpen,
+  HardDrive,
+  Home,
+  Loader2,
+  RefreshCw,
+  Search,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
+import { formatFileSize } from "@/lib/format-utils";
+
+interface GoogleDriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  createdTime: string;
+  modifiedTime: string;
+  thumbnailLink?: string;
+  webViewLink?: string;
+  parentId?: string;
+}
+
+interface GoogleDriveFolder {
+  id: string;
+  name: string;
+  parentId?: string;
+  modifiedTime: string;
+}
+
+interface BreadcrumbItem {
+  id: string;
+  name: string;
+}
+
+interface GoogleDrivePickerProps {
+  open: boolean;
+  onClose: () => void;
+  onImport: (files: GoogleDriveFile[]) => Promise<void>;
+}
+
+export function GoogleDrivePicker({ open, onClose, onImport }: GoogleDrivePickerProps) {
+  const { toast } = useToast();
+  const [files, setFiles] = useState<GoogleDriveFile[]>([]);
+  const [folders, setFolders] = useState<GoogleDriveFolder[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [currentFolderId, setCurrentFolderId] = useState<string | undefined>(undefined);
+  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<GoogleDriveFile[] | null>(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [nextPageToken, setNextPageToken] = useState<string | undefined>();
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+
+  const loadFolderContents = useCallback(
+    async (folderId?: string, reset = false) => {
+      try {
+        setLoading(true);
+        setConnectionError(null);
+
+        const params = new URLSearchParams({
+          action: "list",
+        });
+
+        if (folderId) {
+          params.set("folderId", folderId);
+        }
+
+        if (!reset && nextPageToken) {
+          params.set("pageToken", nextPageToken);
+        }
+
+        const response = await fetch(`/api/integrations/google/drive?${params.toString()}`);
+        const data = await response.json();
+
+        if (!data.success) {
+          if (response.status === 404) {
+            setConnectionError(data.error || "Google account not connected");
+          }
+          throw new Error(data.error || "Failed to load Google Drive contents");
+        }
+
+        if (reset) {
+          setFiles(data.data.files);
+          setFolders(data.data.folders);
+        } else {
+          setFiles((prev) => [...prev, ...data.data.files]);
+          // Folders are only loaded once per directory
+        }
+        setNextPageToken(data.data.nextPageToken);
+      } catch (error) {
+        console.error("Failed to load Google Drive contents:", error);
+        if (!connectionError) {
+          toast({
+            title: "Error",
+            description: error instanceof Error ? error.message : "Failed to load Google Drive contents",
+            variant: "destructive",
+          });
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [nextPageToken, toast, connectionError],
+  );
+
+  const handleSearch = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        setSearchResults(null);
+        return;
+      }
+
+      try {
+        setSearchLoading(true);
+
+        const params = new URLSearchParams({
+          action: "search",
+          query: query.trim(),
+        });
+
+        const response = await fetch(`/api/integrations/google/drive?${params.toString()}`);
+        const data = await response.json();
+
+        if (!data.success) {
+          throw new Error(data.error || "Search failed");
+        }
+
+        setSearchResults(data.data.files);
+      } catch (error) {
+        console.error("Search failed:", error);
+        toast({
+          title: "Search Error",
+          description: error instanceof Error ? error.message : "Search failed",
+          variant: "destructive",
+        });
+      } finally {
+        setSearchLoading(false);
+      }
+    },
+    [toast],
+  );
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setFiles([]);
+      setFolders([]);
+      setSelected(new Set());
+      setCurrentFolderId(undefined);
+      setBreadcrumbs([]);
+      setSearchQuery("");
+      setSearchResults(null);
+      setNextPageToken(undefined);
+      setConnectionError(null);
+      loadFolderContents(undefined, true);
+    }
+  }, [open, loadFolderContents]);
+
+  // Debounced search
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      handleSearch(searchQuery);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery, handleSearch]);
+
+  const navigateToFolder = (folder: GoogleDriveFolder) => {
+    setSelected(new Set());
+    setSearchQuery("");
+    setSearchResults(null);
+    setCurrentFolderId(folder.id);
+    setBreadcrumbs((prev) => [...prev, { id: folder.id, name: folder.name }]);
+    setNextPageToken(undefined);
+    loadFolderContents(folder.id, true);
+  };
+
+  const navigateToBreadcrumb = (index: number) => {
+    const targetBreadcrumb = breadcrumbs[index];
+    setSelected(new Set());
+    setSearchQuery("");
+    setSearchResults(null);
+
+    if (index === -1) {
+      // Go to root
+      setCurrentFolderId(undefined);
+      setBreadcrumbs([]);
+      setNextPageToken(undefined);
+      loadFolderContents(undefined, true);
+    } else {
+      setCurrentFolderId(targetBreadcrumb.id);
+      setBreadcrumbs((prev) => prev.slice(0, index + 1));
+      setNextPageToken(undefined);
+      loadFolderContents(targetBreadcrumb.id, true);
+    }
+  };
+
+  const navigateBack = () => {
+    if (breadcrumbs.length === 0) return;
+
+    const newBreadcrumbs = breadcrumbs.slice(0, -1);
+    const parentId = newBreadcrumbs.length > 0 ? newBreadcrumbs[newBreadcrumbs.length - 1].id : undefined;
+
+    setSelected(new Set());
+    setSearchQuery("");
+    setSearchResults(null);
+    setCurrentFolderId(parentId);
+    setBreadcrumbs(newBreadcrumbs);
+    setNextPageToken(undefined);
+    loadFolderContents(parentId, true);
+  };
+
+  const handleToggle = (fileId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(fileId)) {
+        next.delete(fileId);
+      } else {
+        next.add(fileId);
+      }
+      return next;
+    });
+  };
+
+  const displayedFiles = searchResults ?? files;
+
+  const handleSelectAll = () => {
+    if (selected.size === displayedFiles.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(displayedFiles.map((f) => f.id)));
+    }
+  };
+
+  const handleImport = async () => {
+    if (selected.size === 0) return;
+
+    try {
+      setImporting(true);
+
+      const selectedFiles = displayedFiles.filter((f) => selected.has(f.id));
+      await onImport(selectedFiles);
+
+      toast({
+        title: "Import Started",
+        description: `${selectedFiles.length} video${selectedFiles.length !== 1 ? "s" : ""} are being imported from Google Drive.`,
+      });
+
+      onClose();
+    } catch (error) {
+      console.error("Failed to import from Google Drive:", error);
+      toast({
+        title: "Import Failed",
+        description: error instanceof Error ? error.message : "Failed to import videos",
+        variant: "destructive",
+      });
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const getTotalSelectedSize = () => {
+    const selectedFiles = displayedFiles.filter((f) => selected.has(f.id));
+    const totalBytes = selectedFiles.reduce((sum, f) => sum + f.size, 0);
+    return formatFileSize(totalBytes);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <HardDrive className="h-5 w-5" />
+            Import from Google Drive
+          </DialogTitle>
+          <DialogDescription>Browse and select videos to import from your Google Drive</DialogDescription>
+        </DialogHeader>
+
+        {connectionError ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <HardDrive className="h-12 w-12 text-muted-foreground mb-4" />
+            <p className="text-muted-foreground text-center">{connectionError}</p>
+            <Button variant="outline" className="mt-4" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        ) : (
+          <>
+            {/* Search and Navigation */}
+            <div className="flex flex-col gap-3 py-2">
+              <div className="flex items-center gap-2">
+                {/* Back button */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={navigateBack}
+                  disabled={breadcrumbs.length === 0 || loading}
+                  className="shrink-0"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+
+                {/* Search */}
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    placeholder="Search videos in Drive..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="pl-9"
+                  />
+                  {searchQuery && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2"
+                      onClick={() => setSearchQuery("")}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  )}
+                </div>
+
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => loadFolderContents(currentFolderId, true)}
+                  disabled={loading}
+                >
+                  <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+                </Button>
+              </div>
+
+              {/* Breadcrumbs */}
+              {!searchQuery && (
+                <div className="flex items-center gap-1 text-sm overflow-x-auto">
+                  <button
+                    type="button"
+                    onClick={() => navigateToBreadcrumb(-1)}
+                    className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted shrink-0"
+                  >
+                    <Home className="h-4 w-4" />
+                    <span>My Drive</span>
+                  </button>
+
+                  {breadcrumbs.map((crumb, index) => (
+                    <span key={crumb.id} className="flex items-center gap-1 shrink-0">
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                      <button
+                        type="button"
+                        onClick={() => navigateToBreadcrumb(index)}
+                        className={`px-2 py-1 rounded-md transition-colors ${
+                          index === breadcrumbs.length - 1
+                            ? "font-medium text-foreground"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                        }`}
+                      >
+                        {crumb.name}
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Selection Info */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    checked={displayedFiles.length > 0 && selected.size === displayedFiles.length}
+                    onCheckedChange={handleSelectAll}
+                    disabled={displayedFiles.length === 0 || loading}
+                  />
+                  <span className="text-sm text-muted-foreground">
+                    {selected.size > 0 ? (
+                      <>
+                        {selected.size} selected
+                        <span className="mx-2">·</span>
+                        {getTotalSelectedSize()}
+                      </>
+                    ) : (
+                      `${displayedFiles.length} video${displayedFiles.length !== 1 ? "s" : ""}`
+                    )}
+                  </span>
+                </div>
+                {searchQuery && searchResults && (
+                  <Badge variant="secondary" className="gap-1">
+                    <Search className="h-3 w-3" />
+                    {searchResults.length} result{searchResults.length !== 1 ? "s" : ""}
+                  </Badge>
+                )}
+              </div>
+            </div>
+
+            <ScrollArea className="flex-1 -mx-6 px-6">
+              {loading && files.length === 0 && folders.length === 0 ? (
+                <div className="space-y-2">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <div key={`skeleton-${i}-${currentFolderId}`} className="flex items-center gap-3 p-4">
+                      <Skeleton className="h-5 w-5 rounded" />
+                      <div className="flex-1">
+                        <Skeleton className="h-4 w-48 mb-2" />
+                        <Skeleton className="h-3 w-32" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : searchLoading ? (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                  <p className="mt-2 text-sm text-muted-foreground">Searching...</p>
+                </div>
+              ) : folders.length === 0 && displayedFiles.length === 0 ? (
+                <div className="text-center py-12">
+                  <FolderOpen className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                  {searchQuery ? (
+                    <>
+                      <p className="text-muted-foreground">No videos match your search</p>
+                      <Button variant="link" className="mt-2" onClick={() => setSearchQuery("")}>
+                        Clear search
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-muted-foreground">No videos in this folder</p>
+                      <p className="text-sm text-muted-foreground mt-1">Navigate to a folder containing video files</p>
+                    </>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {/* Folders (only shown when not searching) */}
+                  {!searchQuery &&
+                    folders.map((folder) => (
+                      <div
+                        key={folder.id}
+                        role="button"
+                        tabIndex={0}
+                        className="group flex items-center gap-3 p-4 rounded-lg border hover:bg-muted/50 hover:border-muted-foreground/20 transition-all cursor-pointer"
+                        onClick={() => navigateToFolder(folder)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            navigateToFolder(folder);
+                          }
+                        }}
+                      >
+                        <Folder className="h-5 w-5 text-blue-500 shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium truncate group-hover:text-primary transition-colors">
+                            {folder.name}
+                          </p>
+                        </div>
+                        <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+                      </div>
+                    ))}
+
+                  {/* Files */}
+                  {displayedFiles.map((file) => {
+                    const isSelected = selected.has(file.id);
+
+                    return (
+                      <div
+                        key={file.id}
+                        role="button"
+                        tabIndex={0}
+                        className={`group flex items-start gap-3 p-4 rounded-lg border transition-all cursor-pointer hover:shadow-sm ${
+                          isSelected
+                            ? "bg-primary/5 border-primary/50 shadow-sm"
+                            : "hover:bg-muted/50 hover:border-muted-foreground/20"
+                        }`}
+                        onClick={() => handleToggle(file.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleToggle(file.id);
+                          }
+                        }}
+                      >
+                        <div className="flex items-center justify-center pt-0.5">
+                          <Checkbox
+                            checked={isSelected}
+                            onCheckedChange={() => handleToggle(file.id)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+                          />
+                        </div>
+
+                        {/* Thumbnail or icon */}
+                        <div className="w-12 h-12 shrink-0 rounded-md bg-muted flex items-center justify-center overflow-hidden">
+                          {file.thumbnailLink ? (
+                            // biome-ignore lint/performance/noImgElement: External Google Drive thumbnails require dynamic domains
+                            <img
+                              src={file.thumbnailLink}
+                              alt=""
+                              className="w-full h-full object-cover"
+                              onError={(e) => {
+                                e.currentTarget.style.display = "none";
+                                if (e.currentTarget.nextElementSibling) {
+                                  (e.currentTarget.nextElementSibling as HTMLElement).style.display = "flex";
+                                }
+                              }}
+                            />
+                          ) : null}
+                          <FileVideo
+                            className="h-6 w-6 text-muted-foreground"
+                            style={{ display: file.thumbnailLink ? "none" : "block" }}
+                          />
+                        </div>
+
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="flex-1 min-w-0">
+                              <p className="font-medium truncate group-hover:text-primary transition-colors">
+                                {file.name}
+                              </p>
+                              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-sm text-muted-foreground">
+                                <span className="flex items-center gap-1.5">
+                                  {format(new Date(file.modifiedTime), "MMM d, yyyy")}
+                                  <span className="text-muted-foreground/60">
+                                    ({formatDistanceToNow(new Date(file.modifiedTime), { addSuffix: true })})
+                                  </span>
+                                </span>
+                                <span className="flex items-center gap-1.5">
+                                  <Download className="h-3.5 w-3.5" />
+                                  {formatFileSize(file.size)}
+                                </span>
+                              </div>
+                            </div>
+
+                            {isSelected && (
+                              <Badge className="shrink-0 bg-primary">
+                                <Check className="h-3 w-3 mr-1" />
+                                Selected
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                  {nextPageToken && !searchQuery && (
+                    <Button
+                      variant="outline"
+                      className="w-full mt-4"
+                      onClick={() => loadFolderContents(currentFolderId)}
+                      disabled={loading}
+                    >
+                      {loading ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Loading...
+                        </>
+                      ) : (
+                        "Load More Videos"
+                      )}
+                    </Button>
+                  )}
+                </div>
+              )}
+            </ScrollArea>
+
+            <DialogFooter className="border-t pt-4 gap-2 sm:gap-0">
+              <div className="flex-1 text-sm text-muted-foreground hidden sm:block">
+                {selected.size > 0 && (
+                  <span>
+                    Ready to import {selected.size} video{selected.size !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </div>
+              <Button variant="outline" onClick={onClose} disabled={importing}>
+                Cancel
+              </Button>
+              <Button onClick={handleImport} disabled={selected.size === 0 || importing} className="gap-2">
+                {importing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Importing...
+                  </>
+                ) : (
+                  <>
+                    <Download className="h-4 w-4" />
+                    Import {selected.size > 0 ? `${selected.size} ` : ""}Video
+                    {selected.size !== 1 ? "s" : ""}
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
This commit introduces several major improvements to the video import workflow:

## Google Drive Integration
- Add listVideoFiles, listFolders, and searchVideos methods to google-meet service
- Create API endpoint for browsing Google Drive (/api/integrations/google/drive)
- Create GoogleDrivePicker component for browsing and selecting videos

## Presigned URL Upload
- Add presigned URL API endpoint to bypass Vercel API route size limits
- Add upload confirmation endpoint for creating video records after direct upload
- Support for up to 5GB files uploaded directly to Cloudflare R2

## Bulk Upload
- Create BulkVideoUpload component with multi-file support
- Progress tracking for individual and overall uploads
- Concurrent upload support (up to 3 files at once)
- Support for up to 20 files per batch

## Import Hub
- Create unified ImportHub component with all import sources
- Tabbed interface for local files and external sources
- Integration with existing Zoom and Google Meet recording browsers

## Documentation
- Update integrations.md with new features and API endpoints