### PR TITLE
Fix internal server error in knowledge context API

### DIFF
--- a/src/app/api/code-context/route.ts
+++ b/src/app/api/code-context/route.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { NextRequest } from "next/server";
+import { connection } from "next/server";
 import { createPublicLayer, handleEffectExit } from "@/lib/api-handler";
 import type { CodeLinkType } from "@/lib/db/schema";
 import { CodeLinksRepository } from "@/lib/effect";
@@ -9,6 +10,8 @@ import { CodeLinksRepository } from "@/lib/effect";
 // =============================================================================
 
 export async function GET(request: NextRequest) {
+  await connection();
+
   const effect = Effect.gen(function* () {
     const { searchParams } = new URL(request.url);
     const repo = searchParams.get("repo");

--- a/src/app/api/embed/[id]/route.ts
+++ b/src/app/api/embed/[id]/route.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { type NextRequest, NextResponse } from "next/server";
+import { connection, type NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { organizations, videoShareLinks, videos } from "@/lib/db/schema";
 
@@ -8,6 +8,8 @@ import { organizations, videoShareLinks, videos } from "@/lib/db/schema";
 // =============================================================================
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await connection();
+
   const { id } = await params;
 
   try {

--- a/src/app/api/embed/[id]/view/route.ts
+++ b/src/app/api/embed/[id]/view/route.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from "drizzle-orm";
-import { type NextRequest, NextResponse } from "next/server";
+import { connection, type NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { videoShareLinks, videos, videoViews } from "@/lib/db/schema";
 
@@ -8,6 +8,8 @@ import { videoShareLinks, videos, videoViews } from "@/lib/db/schema";
 // =============================================================================
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await connection();
+
   const { id } = await params;
 
   try {

--- a/src/app/api/knowledge/context/route.ts
+++ b/src/app/api/knowledge/context/route.ts
@@ -1,5 +1,5 @@
 import { Cause, Effect, Exit, Layer, Schema } from "effect";
-import { type NextRequest, NextResponse } from "next/server";
+import { connection, type NextRequest, NextResponse } from "next/server";
 import { mapErrorToApiResponse } from "@/lib/api-errors";
 import { CachePresets, getCacheControlHeader } from "@/lib/api-utils";
 import { auth } from "@/lib/auth";
@@ -26,6 +26,8 @@ const getContextQuerySchema = Schema.Struct({
 // =============================================================================
 
 export async function GET(request: NextRequest) {
+  await connection();
+
   const AuthLayer = makeAuthLayer(auth);
   const FullLayer = Layer.merge(AppLive, AuthLayer);
 

--- a/src/app/api/knowledge/graph/route.ts
+++ b/src/app/api/knowledge/graph/route.ts
@@ -1,5 +1,5 @@
 import { Cause, Effect, Exit, Layer, Schema } from "effect";
-import { type NextRequest, NextResponse } from "next/server";
+import { connection, type NextRequest, NextResponse } from "next/server";
 import { mapErrorToApiResponse } from "@/lib/api-errors";
 import { CachePresets, getCacheControlHeader } from "@/lib/api-utils";
 import { auth } from "@/lib/auth";
@@ -28,6 +28,8 @@ const getGraphQuerySchema = Schema.Struct({
 // =============================================================================
 
 export async function GET(request: NextRequest) {
+  await connection();
+
   const AuthLayer = makeAuthLayer(auth);
   const FullLayer = Layer.merge(AppLive, AuthLayer);
 

--- a/src/app/api/knowledge/timeline/route.ts
+++ b/src/app/api/knowledge/timeline/route.ts
@@ -1,5 +1,5 @@
 import { Cause, Effect, Exit, Layer, Schema } from "effect";
-import { type NextRequest, NextResponse } from "next/server";
+import { connection, type NextRequest, NextResponse } from "next/server";
 import { mapErrorToApiResponse } from "@/lib/api-errors";
 import { CachePresets, getCacheControlHeader } from "@/lib/api-utils";
 import { auth } from "@/lib/auth";
@@ -29,6 +29,8 @@ const getTimelineQuerySchema = Schema.Struct({
 // =============================================================================
 
 export async function GET(request: NextRequest) {
+  await connection();
+
   const AuthLayer = makeAuthLayer(auth);
   const FullLayer = Layer.merge(AppLive, AuthLayer);
 


### PR DESCRIPTION
API routes accessing database or authentication were failing during static page generation. Fixed by adding `await connection()` from `next/server` at the start of route handlers.

Routes fixed:
- /api/knowledge/context
- /api/knowledge/graph
- /api/knowledge/timeline
- /api/code-context
- /api/embed/[id]
- /api/embed/[id]/view

Also updated documentation to explain that `export const dynamic` no longer works on Vercel and `await connection()` should be used.