### PR TITLE
Add DISABLE_SIGNUPS env var to control user registration

### DIFF
--- a/docs/internal/reference/environment-config.md
+++ b/docs/internal/reference/environment-config.md
@@ -45,6 +45,9 @@ GITHUB_CLIENT_SECRET="your-github-client-secret"
 # Google OAuth (optional)
 GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
+
+# Disable new user signups (for staging environments)
+DISABLE_SIGNUPS="true"  # Set to "true" or "1" to disable signups
 ```
 
 ### AI Integration

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -67,7 +67,7 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: true,
-    disableSignUp: true,
+    disableSignUp: env.DISABLE_SIGNUPS,
     async sendVerificationEmail({
       user,
       token,

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -54,6 +54,14 @@ export const ServerEnv = Schema.Struct({
   SLACK_MONITORING_WEBHOOK_BILLING: Schema.optional(Schema.String.pipe(Schema.filter((s) => URL.canParse(s)))),
   SLACK_MONITORING_WEBHOOK_USAGE: Schema.optional(Schema.String.pipe(Schema.filter((s) => URL.canParse(s)))),
   SLACK_MONITORING_WEBHOOK_ERRORS: Schema.optional(Schema.String.pipe(Schema.filter((s) => URL.canParse(s)))),
+  // Signup control (for staging deployments)
+  DISABLE_SIGNUPS: Schema.optionalWith(
+    Schema.transform(Schema.String, Schema.Boolean, {
+      decode: (s) => s === "true" || s === "1",
+      encode: (b) => (b ? "true" : "false"),
+    }),
+    { default: () => false },
+  ),
   // Vercel auto-provided environment variables (server-side only)
   VERCEL_URL: Schema.optional(Schema.String),
   VERCEL_PROJECT_PRODUCTION_URL: Schema.optional(Schema.String),


### PR DESCRIPTION
Adds a DISABLE_SIGNUPS environment variable that allows disabling new user signups for staging deployments. Set to "true" or "1" to disable. Defaults to false (signups enabled).