### PR TITLE
Add comprehensive tests with Effect dependency injection

### DIFF
--- a/src/lib/effect/services/auth.test.ts
+++ b/src/lib/effect/services/auth.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Auth Service Tests
+ *
+ * Tests the Auth service using Effect-TS patterns with mocked auth instance.
+ */
+
+import { Effect, Exit, Option } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Auth, makeAuthLayer, type UserSession } from "./auth";
+
+describe("Auth Service", () => {
+  const mockUser = {
+    id: "user-123",
+    email: "test@example.com",
+    name: "Test User",
+    role: "user",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    emailVerified: true,
+  } as const;
+
+  const mockSession = {
+    id: "session-123",
+    userId: "user-123",
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    token: "test-token",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: "127.0.0.1",
+    userAgent: "test-agent",
+  } as const;
+
+  const mockUserSession = {
+    user: mockUser,
+    session: mockSession,
+  } as unknown as UserSession;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockAuthInstance: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthInstance = {
+      api: {
+        getSession: vi.fn(),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createTestLayer = () => makeAuthLayer(mockAuthInstance);
+
+  describe("getSession", () => {
+    it("should return session when authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(mockUserSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSession(new Headers());
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.user.id).toBe("user-123");
+      expect(result.session.id).toBe("session-123");
+    });
+
+    it("should fail with UnauthorizedError when not authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(null);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSession(new Headers());
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail when session API throws", async () => {
+      mockAuthInstance.api.getSession.mockRejectedValueOnce(new Error("API error"));
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSession(new Headers());
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should pass headers to auth instance", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(mockUserSession);
+      const testLayer = createTestLayer();
+
+      const headers = new Headers({
+        cookie: "session=abc123",
+        authorization: "Bearer token",
+      });
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSession(headers);
+      });
+
+      await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(mockAuthInstance.api.getSession).toHaveBeenCalledWith({ headers });
+    });
+  });
+
+  describe("getSessionOption", () => {
+    it("should return Some when authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(mockUserSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSessionOption(new Headers());
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(Option.isSome(result)).toBe(true);
+      if (Option.isSome(result)) {
+        expect(result.value.user.id).toBe("user-123");
+      }
+    });
+
+    it("should return None when not authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(null);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSessionOption(new Headers());
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(Option.isNone(result)).toBe(true);
+    });
+
+    it("should return None when session API throws", async () => {
+      mockAuthInstance.api.getSession.mockRejectedValueOnce(new Error("API error"));
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.getSessionOption(new Headers());
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(Option.isNone(result)).toBe(true);
+    });
+  });
+
+  describe("requireAuth", () => {
+    it("should return session when authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(mockUserSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireAuth(new Headers());
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.user.id).toBe("user-123");
+    });
+
+    it("should fail with UnauthorizedError when not authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(null);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireAuth(new Headers());
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("requireRole", () => {
+    it("should succeed when user has required role", async () => {
+      const adminUser = { ...mockUser, role: "admin" };
+      const adminSession = { ...mockUserSession, user: adminUser };
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(adminSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireRole(new Headers(), "admin");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect((result.user as unknown as { role: string }).role).toBe("admin");
+    });
+
+    it("should succeed when user has one of the required roles", async () => {
+      const moderatorUser = { ...mockUser, role: "moderator" };
+      const moderatorSession = { ...mockUserSession, user: moderatorUser };
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(moderatorSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireRole(new Headers(), ["admin", "moderator"]);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect((result.user as unknown as { role: string }).role).toBe("moderator");
+    });
+
+    it("should fail with ForbiddenError when user lacks required role", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(mockUserSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireRole(new Headers(), "admin");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail with UnauthorizedError when not authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(null);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireRole(new Headers(), "admin");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should handle user without role property", async () => {
+      const userWithoutRole = { ...mockUser, role: undefined };
+      const sessionWithoutRole = { ...mockUserSession, user: userWithoutRole };
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(sessionWithoutRole);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireRole(new Headers(), "admin");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("requireAdmin", () => {
+    it("should succeed when user is admin", async () => {
+      const adminUser = { ...mockUser, role: "admin" };
+      const adminSession = { ...mockUserSession, user: adminUser };
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(adminSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireAdmin(new Headers());
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect((result.user as unknown as { role: string }).role).toBe("admin");
+    });
+
+    it("should fail with ForbiddenError when user is not admin", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(mockUserSession);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireAdmin(new Headers());
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail with UnauthorizedError when not authenticated", async () => {
+      mockAuthInstance.api.getSession.mockResolvedValueOnce(null);
+      const testLayer = createTestLayer();
+
+      const program = Effect.gen(function* () {
+        const auth = yield* Auth;
+        return yield* auth.requireAdmin(new Headers());
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+});

--- a/src/lib/effect/services/comment-repository.integration.test.ts
+++ b/src/lib/effect/services/comment-repository.integration.test.ts
@@ -1,0 +1,401 @@
+/**
+ * CommentRepository Integration Tests
+ *
+ * Tests the CommentRepository service using Effect-TS dependency injection
+ * to mock the Database service.
+ */
+
+import { Effect, Exit, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockCommentWithAuthor,
+  createMockDatabaseService,
+  type MockDatabaseService,
+} from "@/test/effect-test-utils";
+import {
+  CommentRepository,
+  CommentRepositoryLive,
+  type CreateCommentInput,
+  type UpdateCommentInput,
+} from "./comment-repository";
+import { Database } from "./database";
+
+describe("CommentRepository Integration Tests", () => {
+  let mockDb: MockDatabaseService;
+  let testLayer: Layer.Layer<CommentRepository>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDatabaseService();
+
+    const DatabaseLayer = Layer.succeed(Database, mockDb as unknown as never);
+    testLayer = CommentRepositoryLive.pipe(Layer.provide(DatabaseLayer));
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getComments", () => {
+    it("should return threaded comments for a video", async () => {
+      const parentComment = createMockCommentWithAuthor({ id: "comment-1", parentId: null });
+      const replyComment = createMockCommentWithAuthor({ id: "comment-2", parentId: "comment-1" });
+
+      mockDb.db.orderBy.mockResolvedValueOnce([parentComment, replyComment]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getComments("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toHaveLength(1); // Only top-level comments
+      expect(result[0].id).toBe("comment-1");
+      expect(result[0].replies).toHaveLength(1);
+      expect(result[0].replies[0].id).toBe("comment-2");
+    });
+
+    it("should return empty array when no comments exist", async () => {
+      mockDb.db.orderBy.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getComments("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should handle nested replies correctly", async () => {
+      const grandparent = createMockCommentWithAuthor({ id: "c1", parentId: null });
+      const parent = createMockCommentWithAuthor({ id: "c2", parentId: "c1" });
+      const child = createMockCommentWithAuthor({ id: "c3", parentId: "c2" });
+
+      mockDb.db.orderBy.mockResolvedValueOnce([grandparent, parent, child]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getComments("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toHaveLength(1);
+      expect((result[0] as unknown as { replies: unknown[] }).replies).toHaveLength(1);
+      expect((result[0] as unknown as { replies: { replies: unknown[] }[] }).replies[0].replies).toHaveLength(1);
+    });
+
+    it("should handle database errors", async () => {
+      mockDb.db.orderBy.mockRejectedValueOnce(new Error("Database connection failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getComments("video-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getComment", () => {
+    it("should return a single comment with author", async () => {
+      const comment = createMockCommentWithAuthor({ id: "comment-123" });
+
+      mockDb.db.limit.mockResolvedValueOnce([comment]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getComment("comment-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("comment-123");
+      expect(result.author).toBeDefined();
+    });
+
+    it("should fail with NotFoundError when comment does not exist", async () => {
+      mockDb.db.limit.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getComment("nonexistent");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("createComment", () => {
+    it("should create a new comment", async () => {
+      const input: CreateCommentInput = {
+        content: "This is a new comment",
+        timestamp: "00:01:30",
+        authorId: "user-123",
+        videoId: "video-123",
+      };
+
+      const createdComment = { id: "new-comment-123", ...input };
+
+      // Mock video exists check
+      mockDb.db.limit.mockResolvedValueOnce([{ id: "video-123" }]);
+      // Mock insert
+      mockDb.db.returning.mockResolvedValueOnce([createdComment]);
+      // Mock getComment for return
+      mockDb.db.limit.mockResolvedValueOnce([createMockCommentWithAuthor({ ...createdComment })]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.createComment(input);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("new-comment-123");
+      expect(result.content).toBe("This is a new comment");
+    });
+
+    it("should fail when video does not exist", async () => {
+      const input: CreateCommentInput = {
+        content: "Comment on nonexistent video",
+        authorId: "user-123",
+        videoId: "nonexistent-video",
+      };
+
+      mockDb.db.limit.mockResolvedValueOnce([]); // Video not found
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.createComment(input);
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should create a reply to an existing comment", async () => {
+      const input: CreateCommentInput = {
+        content: "This is a reply",
+        authorId: "user-123",
+        videoId: "video-123",
+        parentId: "parent-comment-123",
+      };
+
+      const createdReply = { id: "reply-123", ...input };
+
+      // Mock video exists
+      mockDb.db.limit.mockResolvedValueOnce([{ id: "video-123" }]);
+      // Mock parent comment exists
+      mockDb.db.limit.mockResolvedValueOnce([{ id: "parent-comment-123" }]);
+      // Mock insert
+      mockDb.db.returning.mockResolvedValueOnce([createdReply]);
+      // Mock getComment for return
+      mockDb.db.limit.mockResolvedValueOnce([createMockCommentWithAuthor({ ...createdReply })]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.createComment(input);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("reply-123");
+      expect(result.parentId).toBe("parent-comment-123");
+    });
+
+    it("should fail when parent comment does not exist", async () => {
+      const input: CreateCommentInput = {
+        content: "Reply to nonexistent parent",
+        authorId: "user-123",
+        videoId: "video-123",
+        parentId: "nonexistent-parent",
+      };
+
+      mockDb.db.limit.mockResolvedValueOnce([{ id: "video-123" }]); // Video exists
+      mockDb.db.limit.mockResolvedValueOnce([]); // Parent not found
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.createComment(input);
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("updateComment", () => {
+    it("should update a comment when user is the author", async () => {
+      const existingComment = createMockCommentWithAuthor({
+        id: "comment-123",
+        authorId: "user-123",
+        content: "Original content",
+      });
+
+      const updateData: UpdateCommentInput = {
+        content: "Updated content",
+      };
+
+      // Mock getComment
+      mockDb.db.limit.mockResolvedValueOnce([existingComment]);
+      // Mock update
+      mockDb.db.returning.mockResolvedValueOnce([{ ...existingComment, ...updateData }]);
+      // Mock getComment for return
+      mockDb.db.limit.mockResolvedValueOnce([{ ...existingComment, ...updateData }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.updateComment("comment-123", "user-123", updateData);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.content).toBe("Updated content");
+    });
+
+    it("should fail with ForbiddenError when user is not the author", async () => {
+      const existingComment = createMockCommentWithAuthor({
+        id: "comment-123",
+        authorId: "other-user",
+      });
+
+      mockDb.db.limit.mockResolvedValueOnce([existingComment]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.updateComment("comment-123", "user-123", { content: "Hacked!" });
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail with NotFoundError when comment does not exist", async () => {
+      mockDb.db.limit.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.updateComment("nonexistent", "user-123", { content: "Update" });
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("deleteComment", () => {
+    it("should fail with NotFoundError when comment does not exist", async () => {
+      mockDb.db.limit.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.deleteComment("nonexistent", "user-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail with ForbiddenError when user is neither author nor video owner", async () => {
+      const existingComment = createMockCommentWithAuthor({
+        id: "comment-123",
+        authorId: "comment-author",
+        videoId: "video-123",
+      });
+
+      // Mock getComment
+      mockDb.db.limit.mockResolvedValueOnce([existingComment]);
+      // Mock video owner check - different user
+      mockDb.db.limit.mockResolvedValueOnce([{ authorId: "video-owner" }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.deleteComment("comment-123", "random-user");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should handle database errors when fetching comment", async () => {
+      mockDb.db.limit.mockRejectedValueOnce(new Error("Database connection lost"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.deleteComment("comment-123", "user-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getCommentsByTimestamp", () => {
+    it("should return comments within a timestamp range", async () => {
+      const comments = [
+        createMockCommentWithAuthor({ id: "c1", timestamp: "00:01:00" }),
+        createMockCommentWithAuthor({ id: "c2", timestamp: "00:02:00" }),
+        createMockCommentWithAuthor({ id: "c3", timestamp: "00:03:00" }),
+      ];
+
+      mockDb.db.orderBy.mockResolvedValueOnce(comments);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getCommentsByTimestamp("video-123", "00:01:00", "00:02:30");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      // Should filter to only comments within range
+      expect(result.length).toBeLessThanOrEqual(3);
+    });
+
+    it("should return empty array when no comments in range", async () => {
+      const comments = [createMockCommentWithAuthor({ id: "c1", timestamp: "00:10:00" })];
+
+      mockDb.db.orderBy.mockResolvedValueOnce(comments);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getCommentsByTimestamp("video-123", "00:01:00", "00:02:00");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should exclude comments without timestamps", async () => {
+      const comments = [
+        createMockCommentWithAuthor({ id: "c1", timestamp: null }),
+        createMockCommentWithAuthor({ id: "c2", timestamp: "00:01:30" }),
+      ];
+
+      mockDb.db.orderBy.mockResolvedValueOnce(comments);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* CommentRepository;
+        return yield* repo.getCommentsByTimestamp("video-123", "00:01:00", "00:02:00");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.every((c) => c.timestamp !== null)).toBe(true);
+    });
+  });
+});

--- a/src/lib/effect/services/notification-repository.integration.test.ts
+++ b/src/lib/effect/services/notification-repository.integration.test.ts
@@ -1,0 +1,484 @@
+/**
+ * NotificationRepository Integration Tests
+ *
+ * Tests the NotificationRepository service using Effect-TS dependency injection
+ * to mock the Database service.
+ */
+
+import { Effect, Exit, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockDatabaseService, createMockNotification, type MockDatabaseService } from "@/test/effect-test-utils";
+import { createMockUser } from "@/test/mocks";
+import { Database } from "./database";
+import {
+  type CreateNotificationInput,
+  NotificationRepository,
+  NotificationRepositoryLive,
+} from "./notification-repository";
+
+describe("NotificationRepository Integration Tests", () => {
+  let mockDb: MockDatabaseService;
+  let testLayer: Layer.Layer<NotificationRepository>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDatabaseService();
+
+    const DatabaseLayer = Layer.succeed(Database, mockDb as unknown as never);
+    testLayer = NotificationRepositoryLive.pipe(Layer.provide(DatabaseLayer));
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getNotifications", () => {
+    it("should return notifications with unread count", async () => {
+      const mockNotifications = [
+        { ...createMockNotification(), actor: createMockUser() },
+        { ...createMockNotification({ id: "n2", read: true }), actor: createMockUser() },
+      ];
+
+      mockDb.db.query.notifications.findMany.mockResolvedValueOnce(mockNotifications);
+      mockDb.db.where.mockResolvedValueOnce([{ count: 1 }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getNotifications("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.data).toHaveLength(2);
+      expect(result.unreadCount).toBe(1);
+    });
+
+    it("should use default pagination", async () => {
+      mockDb.db.query.notifications.findMany.mockResolvedValueOnce([]);
+      mockDb.db.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getNotifications("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.data).toHaveLength(0);
+      expect(result.unreadCount).toBe(0);
+    });
+
+    it("should handle custom pagination", async () => {
+      mockDb.db.query.notifications.findMany.mockResolvedValueOnce([]);
+      mockDb.db.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getNotifications("user-123", 2, 10);
+      });
+
+      await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(mockDb.db.query.notifications.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          offset: 10, // (page - 1) * limit = (2 - 1) * 10
+        }),
+      );
+    });
+
+    it("should handle database errors", async () => {
+      mockDb.db.query.notifications.findMany.mockRejectedValueOnce(new Error("Connection failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getNotifications("user-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getUnreadCount", () => {
+    it("should return unread notification count", async () => {
+      mockDb.db.where.mockResolvedValueOnce([{ count: 5 }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getUnreadCount("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBe(5);
+    });
+
+    it("should return 0 when no unread notifications", async () => {
+      mockDb.db.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getUnreadCount("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBe(0);
+    });
+
+    it("should return 0 when result is null", async () => {
+      mockDb.db.where.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.getUnreadCount("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("createNotification", () => {
+    it("should create a notification", async () => {
+      const input: CreateNotificationInput = {
+        userId: "user-123",
+        type: "comment_reply",
+        title: "New reply",
+        body: "Someone replied to your comment",
+      };
+
+      const createdNotification = {
+        id: "notification-new",
+        ...input,
+        read: false,
+        createdAt: new Date(),
+      };
+
+      mockDb.db.returning.mockResolvedValueOnce([createdNotification]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.createNotification(input);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("notification-new");
+      expect(result.type).toBe("comment_reply");
+      expect(mockDb.db.insert).toHaveBeenCalled();
+    });
+
+    it("should create notification with optional fields", async () => {
+      const input: CreateNotificationInput = {
+        userId: "user-123",
+        type: "video_shared",
+        title: "Video shared with you",
+        resourceType: "video",
+        resourceId: "video-123",
+        actorId: "actor-456",
+      };
+
+      const createdNotification = { id: "n1", ...input };
+      mockDb.db.returning.mockResolvedValueOnce([createdNotification]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.createNotification(input);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.resourceType).toBe("video");
+      expect(result.resourceId).toBe("video-123");
+      expect(result.actorId).toBe("actor-456");
+    });
+
+    it("should handle creation errors", async () => {
+      mockDb.db.returning.mockRejectedValueOnce(new Error("Insert failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.createNotification({
+          userId: "user-123",
+          type: "comment_reply",
+          title: "Test",
+        });
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("notifyCommentReply", () => {
+    it("should create notification for comment reply", async () => {
+      const parentComment = {
+        id: "parent-123",
+        authorId: "parent-author",
+        author: createMockUser({ id: "parent-author" }),
+      };
+      const actor = createMockUser({ id: "replier", name: "Replier User" });
+
+      mockDb.db.query.comments.findFirst.mockResolvedValueOnce(parentComment);
+      mockDb.db.query.users.findFirst.mockResolvedValueOnce(actor);
+      mockDb.db.returning.mockResolvedValueOnce([
+        {
+          id: "notification-123",
+          type: "comment_reply",
+          userId: "parent-author",
+          actorId: "replier",
+        },
+      ]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyCommentReply("parent-123", "reply-123", "replier", "video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("comment_reply");
+    });
+
+    it("should not notify when replying to own comment", async () => {
+      const parentComment = {
+        id: "parent-123",
+        authorId: "same-user",
+        author: createMockUser({ id: "same-user" }),
+      };
+
+      mockDb.db.query.comments.findFirst.mockResolvedValueOnce(parentComment);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyCommentReply("parent-123", "reply-123", "same-user", "video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when parent comment does not exist", async () => {
+      mockDb.db.query.comments.findFirst.mockResolvedValueOnce(null);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyCommentReply("nonexistent", "reply-123", "user-123", "video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("notifyNewCommentOnVideo", () => {
+    it("should create notification for new comment on video", async () => {
+      const video = {
+        id: "video-123",
+        title: "Test Video",
+        authorId: "video-owner",
+      };
+      const actor = createMockUser({ id: "commenter", name: "Commenter User" });
+
+      mockDb.db.query.videos.findFirst.mockResolvedValueOnce(video);
+      mockDb.db.query.users.findFirst.mockResolvedValueOnce(actor);
+      mockDb.db.returning.mockResolvedValueOnce([
+        {
+          id: "notification-123",
+          type: "new_comment_on_video",
+          userId: "video-owner",
+        },
+      ]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyNewCommentOnVideo("video-123", "comment-123", "commenter");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("new_comment_on_video");
+    });
+
+    it("should not notify when commenting on own video", async () => {
+      const video = {
+        id: "video-123",
+        title: "My Video",
+        authorId: "same-user",
+      };
+
+      mockDb.db.query.videos.findFirst.mockResolvedValueOnce(video);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyNewCommentOnVideo("video-123", "comment-123", "same-user");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when video does not exist", async () => {
+      mockDb.db.query.videos.findFirst.mockResolvedValueOnce(null);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyNewCommentOnVideo("nonexistent", "comment-123", "user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when video has no author", async () => {
+      const video = {
+        id: "video-123",
+        title: "Orphaned Video",
+        authorId: null,
+      };
+
+      mockDb.db.query.videos.findFirst.mockResolvedValueOnce(video);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.notifyNewCommentOnVideo("video-123", "comment-123", "user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("markAsRead", () => {
+    it("should mark a notification as read", async () => {
+      const updatedNotification = {
+        id: "notification-123",
+        userId: "user-123",
+        read: true,
+      };
+
+      mockDb.db.returning.mockResolvedValueOnce([updatedNotification]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.markAsRead("notification-123", "user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.read).toBe(true);
+      expect(mockDb.db.update).toHaveBeenCalled();
+    });
+
+    it("should fail with NotFoundError when notification does not exist", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.markAsRead("nonexistent", "user-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail when notification belongs to different user", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.markAsRead("notification-123", "wrong-user");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("markAllAsRead", () => {
+    it("should mark all unread notifications as read", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([
+        { id: "n1", read: true },
+        { id: "n2", read: true },
+        { id: "n3", read: true },
+      ]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.markAllAsRead("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBe(3);
+    });
+
+    it("should return 0 when no unread notifications", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.markAllAsRead("user-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("deleteNotification", () => {
+    it("should delete a notification", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([{ id: "notification-123" }]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.deleteNotification("notification-123", "user-123");
+      });
+
+      await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(mockDb.db.delete).toHaveBeenCalled();
+    });
+
+    it("should fail with NotFoundError when notification does not exist", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.deleteNotification("nonexistent", "user-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should fail when notification belongs to different user", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* NotificationRepository;
+        return yield* repo.deleteNotification("notification-123", "wrong-user");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+});

--- a/src/lib/effect/services/storage.test.ts
+++ b/src/lib/effect/services/storage.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Storage Service Tests
+ *
+ * Tests the Storage service using Effect-TS patterns with mocked service.
+ */
+
+import { Effect, Exit, Layer } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import { DeleteError, PresignedUrlError, StorageNotConfiguredError, UploadError } from "../errors";
+import { Storage, type StorageService, type UploadResult } from "./storage";
+
+describe("Storage Service", () => {
+  // Create a mock storage service for testing
+  const createMockStorageService = (isConfigured = true): StorageService => ({
+    uploadFile: vi.fn().mockImplementation((buffer, key, options) =>
+      isConfigured
+        ? Effect.succeed({
+            key,
+            url: `https://storage.example.com/${key}`,
+            etag: "mock-etag",
+          } as UploadResult)
+        : Effect.fail(new UploadError({ message: "Storage not configured", filename: key })),
+    ),
+
+    uploadLargeFile: vi.fn().mockImplementation((buffer, key, options, onProgress) => {
+      if (!isConfigured) {
+        return Effect.fail(new UploadError({ message: "Storage not configured", filename: key }));
+      }
+      // Simulate progress callback
+      if (onProgress) {
+        onProgress({ loaded: 512, total: 1024 });
+      }
+      return Effect.succeed({
+        key,
+        url: `https://storage.example.com/${key}`,
+        etag: "large-file-etag",
+      } as UploadResult);
+    }),
+
+    deleteFile: vi
+      .fn()
+      .mockImplementation((key) =>
+        isConfigured ? Effect.void : Effect.fail(new DeleteError({ message: "Storage not configured", key })),
+      ),
+
+    generatePresignedUploadUrl: vi
+      .fn()
+      .mockImplementation((key, contentType, expiresIn) =>
+        isConfigured
+          ? Effect.succeed(`https://storage.example.com/presigned/${key}?expires=${expiresIn ?? 3600}`)
+          : Effect.fail(new PresignedUrlError({ message: "Storage not configured" })),
+      ),
+
+    getPublicUrl: vi.fn().mockImplementation((key) => `https://storage.example.com/${key}`),
+
+    generateFileKey: vi.fn().mockImplementation((organizationId, filename, type = "video") => {
+      const timestamp = Date.now();
+      const sanitizedFilename = filename.replace(/[^a-zA-Z0-9.-]/g, "_");
+      return `${organizationId}/${type}s/${timestamp}-${sanitizedFilename}`;
+    }),
+
+    isConfigured,
+  });
+
+  const createTestLayer = (service: StorageService) => Layer.succeed(Storage, service);
+
+  describe("with configured storage", () => {
+    describe("uploadFile", () => {
+      it("should upload a file successfully", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+        const buffer = Buffer.from("test content");
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.uploadFile(buffer, "test/file.txt", {
+            contentType: "text/plain",
+          });
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result.key).toBe("test/file.txt");
+        expect(result.url).toContain("test/file.txt");
+        expect(result.etag).toBe("mock-etag");
+      });
+
+      it("should handle upload errors", async () => {
+        const mockService = createMockStorageService();
+        (mockService as { uploadFile: unknown }).uploadFile = vi
+          .fn()
+          .mockImplementation(() => Effect.fail(new UploadError({ message: "Upload failed", filename: "test.txt" })));
+        const testLayer = createTestLayer(mockService);
+        const buffer = Buffer.from("test");
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.uploadFile(buffer, "test/fail.txt");
+        });
+
+        const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      });
+    });
+
+    describe("uploadLargeFile", () => {
+      it("should upload a large file with progress tracking", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+        const progressCallback = vi.fn();
+        const buffer = Buffer.alloc(1024);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.uploadLargeFile(
+            buffer,
+            "test/large-file.bin",
+            { contentType: "application/octet-stream" },
+            progressCallback,
+          );
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result.key).toBe("test/large-file.bin");
+        expect(result.etag).toBe("large-file-etag");
+      });
+    });
+
+    describe("deleteFile", () => {
+      it("should delete a file successfully", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.deleteFile("test/file-to-delete.txt");
+        });
+
+        await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(mockService.deleteFile).toHaveBeenCalledWith("test/file-to-delete.txt");
+      });
+
+      it("should handle delete errors", async () => {
+        const mockService = createMockStorageService();
+        (mockService as { deleteFile: unknown }).deleteFile = vi
+          .fn()
+          .mockImplementation(() => Effect.fail(new DeleteError({ message: "Delete failed", key: "test.txt" })));
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.deleteFile("test/nonexistent.txt");
+        });
+
+        const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      });
+    });
+
+    describe("generatePresignedUploadUrl", () => {
+      it("should generate a presigned URL", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.generatePresignedUploadUrl("test/upload-target.mp4", "video/mp4", 3600);
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toContain("test/upload-target.mp4");
+        expect(result).toContain("expires=3600");
+      });
+
+      it("should use default expiry when not provided", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.generatePresignedUploadUrl("test/file.mp4", "video/mp4");
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toContain("expires=3600");
+      });
+
+      it("should handle presigned URL errors", async () => {
+        const mockService = createMockStorageService();
+        (mockService as { generatePresignedUploadUrl: unknown }).generatePresignedUploadUrl = vi
+          .fn()
+          .mockImplementation(() => Effect.fail(new PresignedUrlError({ message: "Signing failed" })));
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.generatePresignedUploadUrl("test/file.mp4", "video/mp4");
+        });
+
+        const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      });
+    });
+
+    describe("getPublicUrl", () => {
+      it("should return the public URL for a file", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.getPublicUrl("test/file.mp4");
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toContain("test/file.mp4");
+      });
+    });
+
+    describe("generateFileKey", () => {
+      it("should generate a unique file key for videos", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.generateFileKey("org-123", "my-video.mp4", "video");
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toContain("org-123");
+        expect(result).toContain("videos");
+        expect(result).toContain("my-video.mp4");
+      });
+
+      it("should generate a unique file key for thumbnails", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.generateFileKey("org-123", "thumb.jpg", "thumbnail");
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toContain("thumbnails");
+      });
+
+      it("should sanitize filenames", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.generateFileKey("org-123", "my file (1).mp4", "video");
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).not.toContain(" ");
+        expect(result).not.toContain("(");
+        expect(result).not.toContain(")");
+      });
+
+      it("should use video as default type", async () => {
+        const mockService = createMockStorageService();
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.generateFileKey("org-123", "file.mp4");
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toContain("videos");
+      });
+    });
+
+    describe("isConfigured", () => {
+      it("should return true when storage is configured", async () => {
+        const mockService = createMockStorageService(true);
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.isConfigured;
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe("with unconfigured storage", () => {
+    describe("uploadFile", () => {
+      it("should fail with appropriate error", async () => {
+        const mockService = createMockStorageService(false);
+        const testLayer = createTestLayer(mockService);
+        const buffer = Buffer.from("test");
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.uploadFile(buffer, "test/file.txt");
+        });
+
+        const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      });
+    });
+
+    describe("deleteFile", () => {
+      it("should fail with appropriate error", async () => {
+        const mockService = createMockStorageService(false);
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.deleteFile("test/file.txt");
+        });
+
+        const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      });
+    });
+
+    describe("generatePresignedUploadUrl", () => {
+      it("should fail with appropriate error", async () => {
+        const mockService = createMockStorageService(false);
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return yield* storage.generatePresignedUploadUrl("test/file.mp4", "video/mp4");
+        });
+
+        const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+      });
+    });
+
+    describe("isConfigured", () => {
+      it("should return false when storage is not configured", async () => {
+        const mockService = createMockStorageService(false);
+        const testLayer = createTestLayer(mockService);
+
+        const program = Effect.gen(function* () {
+          const storage = yield* Storage;
+          return storage.isConfigured;
+        });
+
+        const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/src/lib/effect/services/stripe.test.ts
+++ b/src/lib/effect/services/stripe.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Stripe Service Tests
+ *
+ * Tests the Stripe service interface structure and error handling.
+ * Full integration testing with Stripe would require the actual Stripe SDK.
+ */
+
+import { Effect, Exit, Layer } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import { StripeApiError, WebhookSignatureError } from "../errors";
+import { type StripeService, StripeServiceTag } from "./stripe";
+
+describe("Stripe Service", () => {
+  // Create a mock Stripe service for testing
+  const createMockStripeService = (): StripeService => ({
+    client: {} as unknown as import("stripe").default,
+
+    createCustomer: vi.fn().mockImplementation(({ email, name }) =>
+      Effect.succeed({
+        id: "cus_test123",
+        email,
+        name,
+        object: "customer" as const,
+        created: Date.now(),
+        livemode: false,
+      }),
+    ),
+
+    getCustomer: vi.fn().mockImplementation((customerId) =>
+      Effect.succeed({
+        id: customerId,
+        email: "test@example.com",
+        object: "customer" as const,
+        created: Date.now(),
+        livemode: false,
+      }),
+    ),
+
+    createCheckoutSession: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        id: "cs_test123",
+        url: "https://checkout.stripe.com/pay/cs_test123",
+        object: "checkout.session" as const,
+      }),
+    ),
+
+    createPortalSession: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        id: "bps_test123",
+        url: "https://billing.stripe.com/session/bps_test123",
+        object: "billing_portal.session" as const,
+      }),
+    ),
+
+    getSubscription: vi.fn().mockImplementation((subscriptionId) =>
+      Effect.succeed({
+        id: subscriptionId,
+        status: "active",
+        object: "subscription" as const,
+      }),
+    ),
+
+    updateSubscription: vi.fn().mockImplementation((subscriptionId) =>
+      Effect.succeed({
+        id: subscriptionId,
+        status: "active",
+        object: "subscription" as const,
+      }),
+    ),
+
+    cancelSubscriptionAtPeriodEnd: vi.fn().mockImplementation((subscriptionId) =>
+      Effect.succeed({
+        id: subscriptionId,
+        status: "active",
+        cancel_at_period_end: true,
+        object: "subscription" as const,
+      }),
+    ),
+
+    resumeSubscription: vi.fn().mockImplementation((subscriptionId) =>
+      Effect.succeed({
+        id: subscriptionId,
+        status: "active",
+        cancel_at_period_end: false,
+        object: "subscription" as const,
+      }),
+    ),
+
+    listInvoices: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        data: [{ id: "in_test123", object: "invoice" as const }],
+        has_more: false,
+        object: "list" as const,
+        url: "/v1/invoices",
+      }),
+    ),
+
+    getInvoice: vi.fn().mockImplementation((invoiceId) =>
+      Effect.succeed({
+        id: invoiceId,
+        status: "paid",
+        object: "invoice" as const,
+      }),
+    ),
+
+    getUpcomingInvoice: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        amount_due: 2900,
+        object: "invoice" as const,
+      }),
+    ),
+
+    listPaymentMethods: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        data: [{ id: "pm_test123", type: "card", object: "payment_method" as const }],
+        has_more: false,
+        object: "list" as const,
+        url: "/v1/payment_methods",
+      }),
+    ),
+
+    attachPaymentMethod: vi.fn().mockImplementation((paymentMethodId) =>
+      Effect.succeed({
+        id: paymentMethodId,
+        customer: "cus_test123",
+        object: "payment_method" as const,
+      }),
+    ),
+
+    detachPaymentMethod: vi.fn().mockImplementation((paymentMethodId) =>
+      Effect.succeed({
+        id: paymentMethodId,
+        customer: null,
+        object: "payment_method" as const,
+      }),
+    ),
+
+    setDefaultPaymentMethod: vi.fn().mockImplementation((customerId) =>
+      Effect.succeed({
+        id: customerId,
+        invoice_settings: { default_payment_method: "pm_test123" },
+        object: "customer" as const,
+      }),
+    ),
+
+    constructWebhookEvent: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        id: "evt_test123",
+        type: "customer.subscription.updated",
+        object: "event" as const,
+        data: { object: { id: "sub_123" } },
+      }),
+    ),
+
+    listPrices: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        data: [{ id: "price_test123", unit_amount: 2900, object: "price" as const }],
+        has_more: false,
+        object: "list" as const,
+        url: "/v1/prices",
+      }),
+    ),
+
+    createPrice: vi.fn().mockImplementation(() =>
+      Effect.succeed({
+        id: "price_new123",
+        unit_amount: 2900,
+        currency: "usd",
+        object: "price" as const,
+      }),
+    ),
+  });
+
+  const createTestLayer = (service: StripeService) => Layer.succeed(StripeServiceTag, service);
+
+  describe("createCustomer", () => {
+    it("should create a customer successfully", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.createCustomer({
+          email: "test@example.com",
+          name: "Test User",
+        });
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("cus_test123");
+      expect(result.email).toBe("test@example.com");
+    });
+
+    it("should handle API errors", async () => {
+      const mockService = createMockStripeService();
+      (mockService as { createCustomer: unknown }).createCustomer = vi
+        .fn()
+        .mockImplementation(() => Effect.fail(new StripeApiError({ message: "Invalid email" })));
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.createCustomer({ email: "invalid" });
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getCustomer", () => {
+    it("should retrieve a customer", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.getCustomer("cus_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("cus_test123");
+    });
+
+    it("should handle customer not found", async () => {
+      const mockService = createMockStripeService();
+      (mockService as { getCustomer: unknown }).getCustomer = vi
+        .fn()
+        .mockImplementation(() => Effect.fail(new StripeApiError({ message: "No such customer" })));
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.getCustomer("cus_nonexistent");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("createCheckoutSession", () => {
+    it("should create a checkout session", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.createCheckoutSession({
+          customerId: "cus_123",
+          priceId: "price_123",
+          successUrl: "https://example.com/success",
+          cancelUrl: "https://example.com/cancel",
+        });
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("cs_test123");
+      expect(result.url).toContain("checkout.stripe.com");
+    });
+  });
+
+  describe("createPortalSession", () => {
+    it("should create a billing portal session", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.createPortalSession({
+          customerId: "cus_123",
+          returnUrl: "https://example.com/settings",
+        });
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("bps_test123");
+      expect(result.url).toContain("billing.stripe.com");
+    });
+  });
+
+  describe("getSubscription", () => {
+    it("should retrieve a subscription", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.getSubscription("sub_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("sub_test123");
+      expect(result.status).toBe("active");
+    });
+  });
+
+  describe("updateSubscription", () => {
+    it("should update a subscription", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.updateSubscription("sub_test123", {});
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("sub_test123");
+    });
+  });
+
+  describe("cancelSubscriptionAtPeriodEnd", () => {
+    it("should cancel subscription at period end", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.cancelSubscriptionAtPeriodEnd("sub_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.cancel_at_period_end).toBe(true);
+    });
+  });
+
+  describe("resumeSubscription", () => {
+    it("should resume a canceled subscription", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.resumeSubscription("sub_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.cancel_at_period_end).toBe(false);
+    });
+  });
+
+  describe("listInvoices", () => {
+    it("should list invoices for a customer", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.listInvoices("cus_123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe("getInvoice", () => {
+    it("should retrieve an invoice", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.getInvoice("in_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("in_test123");
+      expect(result.status).toBe("paid");
+    });
+  });
+
+  describe("getUpcomingInvoice", () => {
+    it("should get upcoming invoice preview", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.getUpcomingInvoice({
+          customerId: "cus_123",
+        });
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.amount_due).toBe(2900);
+    });
+  });
+
+  describe("listPaymentMethods", () => {
+    it("should list payment methods for a customer", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.listPaymentMethods("cus_123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe("attachPaymentMethod", () => {
+    it("should attach a payment method to a customer", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.attachPaymentMethod("pm_test123", "cus_123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("pm_test123");
+      expect(result.customer).toBe("cus_test123");
+    });
+  });
+
+  describe("detachPaymentMethod", () => {
+    it("should detach a payment method", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.detachPaymentMethod("pm_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.customer).toBeNull();
+    });
+  });
+
+  describe("setDefaultPaymentMethod", () => {
+    it("should set default payment method for customer", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.setDefaultPaymentMethod("cus_123", "pm_test123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.invoice_settings.default_payment_method).toBe("pm_test123");
+    });
+  });
+
+  describe("constructWebhookEvent", () => {
+    it("should construct a webhook event", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.constructWebhookEvent('{"id":"evt_test123"}', "t=1234,v1=abc");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("evt_test123");
+      expect(result.type).toBe("customer.subscription.updated");
+    });
+
+    it("should fail with invalid signature", async () => {
+      const mockService = createMockStripeService();
+      (mockService as { constructWebhookEvent: unknown }).constructWebhookEvent = vi
+        .fn()
+        .mockImplementation(() => Effect.fail(new WebhookSignatureError({ message: "Invalid signature" })));
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.constructWebhookEvent('{"id":"evt_test123"}', "invalid_signature");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("listPrices", () => {
+    it("should list prices for a product", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.listPrices("prod_123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe("createPrice", () => {
+    it("should create a price", async () => {
+      const mockService = createMockStripeService();
+      const testLayer = createTestLayer(mockService);
+
+      const program = Effect.gen(function* () {
+        const stripe = yield* StripeServiceTag;
+        return yield* stripe.createPrice({
+          unit_amount: 2900,
+          currency: "usd",
+          recurring: { interval: "month" },
+          product: "prod_123",
+        });
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("price_new123");
+      expect(result.unit_amount).toBe(2900);
+    });
+  });
+});

--- a/src/lib/effect/services/video-repository.integration.test.ts
+++ b/src/lib/effect/services/video-repository.integration.test.ts
@@ -1,0 +1,389 @@
+/**
+ * VideoRepository Integration Tests
+ *
+ * Tests the VideoRepository service using Effect-TS dependency injection.
+ * These tests focus on error handling scenarios that are easier to mock.
+ */
+
+import { Effect, Exit, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockDatabaseService,
+  createMockStorageService,
+  createMockVideoWithFullAuthor,
+  type MockDatabaseService,
+  type MockStorageService,
+} from "@/test/effect-test-utils";
+import { createMockOrganization, createMockVideo } from "@/test/mocks";
+import { DeleteError } from "../errors";
+import { Database } from "./database";
+import { Storage } from "./storage";
+import {
+  type CreateVideoInput,
+  type UpdateVideoInput,
+  VideoRepository,
+  VideoRepositoryLive,
+  type VideoSearchInput,
+} from "./video-repository";
+
+describe("VideoRepository Integration Tests", () => {
+  let mockDb: MockDatabaseService;
+  let mockStorage: MockStorageService;
+  let testLayer: Layer.Layer<VideoRepository>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDatabaseService();
+    mockStorage = createMockStorageService();
+
+    // Create the test layer with mocked dependencies
+    const DatabaseLayer = Layer.succeed(Database, mockDb as unknown as never);
+    const StorageLayer = Layer.succeed(Storage, mockStorage as unknown as never);
+    const DepsLayer = Layer.mergeAll(DatabaseLayer, StorageLayer);
+    testLayer = VideoRepositoryLive.pipe(Layer.provide(DepsLayer));
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getVideos", () => {
+    it("should handle database errors gracefully", async () => {
+      mockDb.db.limit.mockRejectedValueOnce(new Error("Connection failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideos("org-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getVideo", () => {
+    it("should fail with NotFoundError when video does not exist", async () => {
+      mockDb.db.limit.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideo("nonexistent-id");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+
+    it("should handle database errors", async () => {
+      mockDb.db.limit.mockRejectedValueOnce(new Error("Query failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideo("video-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("createVideo", () => {
+    it("should create a new video", async () => {
+      const input: CreateVideoInput = {
+        title: "New Video",
+        duration: "10:00",
+        authorId: "user-123",
+        organizationId: "org-123",
+      };
+
+      const createdVideo = { id: "new-video-123", ...input, createdAt: new Date() };
+      mockDb.db.returning.mockResolvedValueOnce([createdVideo]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.createVideo(input);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.id).toBe("new-video-123");
+      expect(result.title).toBe("New Video");
+      expect(mockDb.db.insert).toHaveBeenCalled();
+    });
+
+    it("should handle creation errors", async () => {
+      const input: CreateVideoInput = {
+        title: "New Video",
+        duration: "10:00",
+        authorId: "user-123",
+        organizationId: "org-123",
+      };
+
+      mockDb.db.returning.mockRejectedValueOnce(new Error("Insert failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.createVideo(input);
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("updateVideo", () => {
+    it("should update an existing video", async () => {
+      const updateData: UpdateVideoInput = {
+        title: "Updated Title",
+        description: "Updated description",
+      };
+
+      const updatedVideo = {
+        id: "video-123",
+        ...updateData,
+        updatedAt: new Date(),
+      };
+      mockDb.db.returning.mockResolvedValueOnce([updatedVideo]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.updateVideo("video-123", updateData);
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.title).toBe("Updated Title");
+      expect(mockDb.db.update).toHaveBeenCalled();
+    });
+
+    it("should fail with NotFoundError when video does not exist", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.updateVideo("nonexistent", { title: "New Title" });
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("softDeleteVideo", () => {
+    it("should soft delete a video with default retention", async () => {
+      const deletedVideo = {
+        id: "video-123",
+        deletedAt: new Date(),
+        retentionUntil: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      };
+      mockDb.db.returning.mockResolvedValueOnce([deletedVideo]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.softDeleteVideo("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.deletedAt).toBeDefined();
+      expect(result.retentionUntil).toBeDefined();
+    });
+
+    it("should fail with NotFoundError when video does not exist", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.softDeleteVideo("nonexistent");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("restoreVideo", () => {
+    it("should restore a soft-deleted video", async () => {
+      const restoredVideo = {
+        id: "video-123",
+        deletedAt: null,
+        retentionUntil: null,
+      };
+      mockDb.db.returning.mockResolvedValueOnce([restoredVideo]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.restoreVideo("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result.deletedAt).toBeNull();
+      expect(result.retentionUntil).toBeNull();
+    });
+
+    it("should fail with NotFoundError when video does not exist", async () => {
+      mockDb.db.returning.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.restoreVideo("nonexistent");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("deleteVideo", () => {
+    it("should fail with NotFoundError when video does not exist", async () => {
+      mockDb.db.limit.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.deleteVideo("nonexistent");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("cleanupExpiredVideos", () => {
+    it("should return 0 when no expired videos exist", async () => {
+      mockDb.db.where.mockResolvedValueOnce([]);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.cleanupExpiredVideos();
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toBe(0);
+    });
+
+    it("should handle database errors", async () => {
+      mockDb.db.where.mockRejectedValueOnce(new Error("Query failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.cleanupExpiredVideos();
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("searchVideos", () => {
+    it("should handle database errors in search", async () => {
+      const searchInput: VideoSearchInput = {
+        query: "test",
+        organizationId: "org-123",
+      };
+
+      mockDb.db.limit.mockRejectedValueOnce(new Error("Search failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.searchVideos(searchInput);
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getVideosByAuthor", () => {
+    it("should handle database errors", async () => {
+      mockDb.db.limit.mockRejectedValueOnce(new Error("Query failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideosByAuthor("author-123", "org-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getVideoChapters", () => {
+    it("should return chapters for a video", async () => {
+      const chapters = [
+        { id: "chapter-1", videoId: "video-123", title: "Introduction", startTime: 0 },
+        { id: "chapter-2", videoId: "video-123", title: "Main Content", startTime: 60 },
+      ];
+
+      mockDb.db.orderBy.mockResolvedValueOnce(chapters);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideoChapters("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toHaveLength(2);
+      expect(result[0].title).toBe("Introduction");
+    });
+
+    it("should handle database errors", async () => {
+      mockDb.db.orderBy.mockRejectedValueOnce(new Error("Query failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideoChapters("video-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+
+  describe("getVideoCodeSnippets", () => {
+    it("should return code snippets for a video", async () => {
+      const snippets = [
+        { id: "snippet-1", videoId: "video-123", language: "javascript", code: "console.log('hello')" },
+      ];
+
+      mockDb.db.orderBy.mockResolvedValueOnce(snippets);
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideoCodeSnippets("video-123");
+      });
+
+      const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].language).toBe("javascript");
+    });
+
+    it("should handle database errors", async () => {
+      mockDb.db.orderBy.mockRejectedValueOnce(new Error("Query failed"));
+
+      const program = Effect.gen(function* () {
+        const repo = yield* VideoRepository;
+        return yield* repo.getVideoCodeSnippets("video-123");
+      });
+
+      const exit = await Effect.runPromiseExit(Effect.provide(program, testLayer));
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    });
+  });
+});

--- a/src/test/effect-test-utils.ts
+++ b/src/test/effect-test-utils.ts
@@ -1,0 +1,532 @@
+/**
+ * Effect-TS Test Utilities
+ *
+ * Provides mock layers and utilities for testing Effect-TS services
+ * using dependency injection patterns.
+ */
+
+import { type Context, Effect, Layer } from "effect";
+import { vi } from "vitest";
+import type { Comment, User, Video } from "@/lib/db/schema";
+import type { CommentWithAuthor, CommentWithReplies } from "@/lib/effect/services/comment-repository";
+import type { NotificationWithActor } from "@/lib/effect/services/notification-repository";
+import type { PaginatedResponse, VideoWithAuthor } from "@/lib/types";
+import { createMockOrganization, createMockUser, createMockVideo } from "./mocks";
+
+// =============================================================================
+// Mock Database Service
+// =============================================================================
+
+export interface MockDatabaseService {
+  db: {
+    select: ReturnType<typeof vi.fn>;
+    from: ReturnType<typeof vi.fn>;
+    where: ReturnType<typeof vi.fn>;
+    innerJoin: ReturnType<typeof vi.fn>;
+    leftJoin: ReturnType<typeof vi.fn>;
+    orderBy: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+    offset: ReturnType<typeof vi.fn>;
+    insert: ReturnType<typeof vi.fn>;
+    values: ReturnType<typeof vi.fn>;
+    returning: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    transaction: ReturnType<typeof vi.fn>;
+    query: {
+      videos: { findFirst: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+      users: { findFirst: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+      comments: { findFirst: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+      organizations: { findFirst: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+      notifications: { findFirst: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+    };
+  };
+  client: unknown;
+}
+
+/**
+ * Creates a chainable mock database for testing
+ */
+export function createMockDatabaseService(): MockDatabaseService {
+  const chainable = () => ({
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([]),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    transaction: vi.fn(),
+    query: {
+      videos: { findFirst: vi.fn(), findMany: vi.fn() },
+      users: { findFirst: vi.fn(), findMany: vi.fn() },
+      comments: { findFirst: vi.fn(), findMany: vi.fn() },
+      organizations: { findFirst: vi.fn(), findMany: vi.fn() },
+      notifications: { findFirst: vi.fn(), findMany: vi.fn() },
+    },
+  });
+
+  const db = chainable();
+
+  // Make chainable methods return 'this' properly
+  db.select.mockReturnValue(db);
+  db.from.mockReturnValue(db);
+  db.where.mockReturnValue(db);
+  db.innerJoin.mockReturnValue(db);
+  db.leftJoin.mockReturnValue(db);
+  db.orderBy.mockReturnValue(db);
+  db.limit.mockReturnValue(db);
+  db.offset.mockReturnValue(db);
+  db.insert.mockReturnValue(db);
+  db.values.mockReturnValue(db);
+  db.update.mockReturnValue(db);
+  db.set.mockReturnValue(db);
+  db.delete.mockReturnValue(db);
+
+  return { db: db as unknown as MockDatabaseService["db"], client: {} };
+}
+
+// Import Database tag from the actual service
+import { Database } from "@/lib/effect/services/database";
+
+/**
+ * Creates a mock Database layer for testing
+ */
+export function createMockDatabaseLayer(mockDb?: MockDatabaseService) {
+  const db = mockDb ?? createMockDatabaseService();
+  return Layer.succeed(Database, db as unknown as Context.Tag.Service<typeof Database>);
+}
+
+// =============================================================================
+// Mock Storage Service
+// =============================================================================
+
+export interface MockStorageService {
+  uploadFile: ReturnType<typeof vi.fn>;
+  uploadLargeFile: ReturnType<typeof vi.fn>;
+  deleteFile: ReturnType<typeof vi.fn>;
+  generatePresignedUploadUrl: ReturnType<typeof vi.fn>;
+  getPublicUrl: ReturnType<typeof vi.fn>;
+  generateFileKey: ReturnType<typeof vi.fn>;
+  isConfigured: boolean;
+}
+
+export function createMockStorageService(): MockStorageService {
+  return {
+    uploadFile: vi
+      .fn()
+      .mockImplementation((_buffer, key) =>
+        Effect.succeed({ key, url: `https://storage.example.com/${key}`, etag: "mock-etag" }),
+      ),
+    uploadLargeFile: vi
+      .fn()
+      .mockImplementation((_buffer, key) =>
+        Effect.succeed({ key, url: `https://storage.example.com/${key}`, etag: "mock-etag" }),
+      ),
+    deleteFile: vi.fn().mockImplementation(() => Effect.void),
+    generatePresignedUploadUrl: vi
+      .fn()
+      .mockImplementation((key) => Effect.succeed(`https://storage.example.com/presigned/${key}`)),
+    getPublicUrl: vi.fn().mockImplementation((key) => `https://storage.example.com/${key}`),
+    generateFileKey: vi
+      .fn()
+      .mockImplementation((orgId, filename, type = "video") => `${orgId}/${type}s/${Date.now()}-${filename}`),
+    isConfigured: true,
+  };
+}
+
+import { Storage } from "@/lib/effect/services/storage";
+
+export function createMockStorageLayer(mockStorage?: MockStorageService) {
+  const storage = mockStorage ?? createMockStorageService();
+  return Layer.succeed(Storage, storage as unknown as Context.Tag.Service<typeof Storage>);
+}
+
+// =============================================================================
+// Mock VideoRepository Service
+// =============================================================================
+
+import { DatabaseError, DeleteError, NotFoundError } from "@/lib/effect/errors";
+import { VideoRepository, type VideoRepositoryService } from "@/lib/effect/services/video-repository";
+
+export interface MockVideoRepositoryService {
+  getVideos: ReturnType<typeof vi.fn>;
+  getDeletedVideos: ReturnType<typeof vi.fn>;
+  getVideo: ReturnType<typeof vi.fn>;
+  createVideo: ReturnType<typeof vi.fn>;
+  updateVideo: ReturnType<typeof vi.fn>;
+  softDeleteVideo: ReturnType<typeof vi.fn>;
+  restoreVideo: ReturnType<typeof vi.fn>;
+  deleteVideo: ReturnType<typeof vi.fn>;
+  cleanupExpiredVideos: ReturnType<typeof vi.fn>;
+  getVideoChapters: ReturnType<typeof vi.fn>;
+  getVideoCodeSnippets: ReturnType<typeof vi.fn>;
+  searchVideos: ReturnType<typeof vi.fn>;
+  getVideosByAuthor: ReturnType<typeof vi.fn>;
+  getChannelVideosWithAuthor: ReturnType<typeof vi.fn>;
+  getVideosSharedByOthers: ReturnType<typeof vi.fn>;
+}
+
+export function createMockVideoRepositoryService(): MockVideoRepositoryService {
+  const mockVideo = createMockVideoWithFullAuthor();
+  const paginatedResponse: PaginatedResponse<VideoWithAuthor> = {
+    data: [mockVideo],
+    pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+  };
+
+  return {
+    getVideos: vi.fn().mockImplementation(() => Effect.succeed(paginatedResponse)),
+    getDeletedVideos: vi.fn().mockImplementation(() => Effect.succeed(paginatedResponse)),
+    getVideo: vi.fn().mockImplementation(() => Effect.succeed(mockVideo)),
+    createVideo: vi.fn().mockImplementation((data) => Effect.succeed({ ...createMockVideo(), ...data })),
+    updateVideo: vi.fn().mockImplementation((id, data) => Effect.succeed({ ...createMockVideo({ id }), ...data })),
+    softDeleteVideo: vi
+      .fn()
+      .mockImplementation((id) => Effect.succeed({ ...createMockVideo({ id }), deletedAt: new Date() })),
+    restoreVideo: vi.fn().mockImplementation((id) => Effect.succeed({ ...createMockVideo({ id }), deletedAt: null })),
+    deleteVideo: vi.fn().mockImplementation(() => Effect.void),
+    cleanupExpiredVideos: vi.fn().mockImplementation(() => Effect.succeed(0)),
+    getVideoChapters: vi.fn().mockImplementation(() => Effect.succeed([])),
+    getVideoCodeSnippets: vi.fn().mockImplementation(() => Effect.succeed([])),
+    searchVideos: vi.fn().mockImplementation(() => Effect.succeed(paginatedResponse)),
+    getVideosByAuthor: vi.fn().mockImplementation(() => Effect.succeed(paginatedResponse)),
+    getChannelVideosWithAuthor: vi.fn().mockImplementation(() => Effect.succeed(paginatedResponse)),
+    getVideosSharedByOthers: vi.fn().mockImplementation(() => Effect.succeed(paginatedResponse)),
+  };
+}
+
+export function createMockVideoRepositoryLayer(mockRepo?: MockVideoRepositoryService) {
+  const repo = mockRepo ?? createMockVideoRepositoryService();
+  return Layer.succeed(VideoRepository, repo as unknown as VideoRepositoryService);
+}
+
+// =============================================================================
+// Mock CommentRepository Service
+// =============================================================================
+
+import { CommentRepository, type CommentRepositoryService } from "@/lib/effect/services/comment-repository";
+
+export interface MockCommentRepositoryService {
+  getComments: ReturnType<typeof vi.fn>;
+  getComment: ReturnType<typeof vi.fn>;
+  createComment: ReturnType<typeof vi.fn>;
+  updateComment: ReturnType<typeof vi.fn>;
+  deleteComment: ReturnType<typeof vi.fn>;
+  getCommentsByTimestamp: ReturnType<typeof vi.fn>;
+}
+
+export function createMockCommentRepositoryService(): MockCommentRepositoryService {
+  const mockComment = createMockCommentWithAuthor();
+
+  return {
+    getComments: vi.fn().mockImplementation(() => Effect.succeed([])),
+    getComment: vi.fn().mockImplementation(() => Effect.succeed(mockComment)),
+    createComment: vi.fn().mockImplementation((data) => Effect.succeed({ ...mockComment, ...data })),
+    updateComment: vi.fn().mockImplementation((id, _authorId, data) => Effect.succeed({ ...mockComment, id, ...data })),
+    deleteComment: vi.fn().mockImplementation((id) => Effect.succeed({ ...mockComment, id })),
+    getCommentsByTimestamp: vi.fn().mockImplementation(() => Effect.succeed([])),
+  };
+}
+
+export function createMockCommentRepositoryLayer(mockRepo?: MockCommentRepositoryService) {
+  const repo = mockRepo ?? createMockCommentRepositoryService();
+  return Layer.succeed(CommentRepository, repo as unknown as CommentRepositoryService);
+}
+
+// =============================================================================
+// Mock NotificationRepository Service
+// =============================================================================
+
+import {
+  NotificationRepository,
+  type NotificationRepositoryService,
+} from "@/lib/effect/services/notification-repository";
+
+export interface MockNotificationRepositoryService {
+  getNotifications: ReturnType<typeof vi.fn>;
+  getUnreadCount: ReturnType<typeof vi.fn>;
+  markAsRead: ReturnType<typeof vi.fn>;
+  markAllAsRead: ReturnType<typeof vi.fn>;
+  createNotification: ReturnType<typeof vi.fn>;
+  deleteNotification: ReturnType<typeof vi.fn>;
+}
+
+export function createMockNotificationRepositoryService(): MockNotificationRepositoryService {
+  return {
+    getNotifications: vi
+      .fn()
+      .mockImplementation(() =>
+        Effect.succeed({ data: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0 } }),
+      ),
+    getUnreadCount: vi.fn().mockImplementation(() => Effect.succeed(0)),
+    markAsRead: vi.fn().mockImplementation(() => Effect.succeed(createMockNotification())),
+    markAllAsRead: vi.fn().mockImplementation(() => Effect.succeed(0)),
+    createNotification: vi.fn().mockImplementation((data) => Effect.succeed({ ...createMockNotification(), ...data })),
+    deleteNotification: vi.fn().mockImplementation(() => Effect.void),
+  };
+}
+
+export function createMockNotificationRepositoryLayer(mockRepo?: MockNotificationRepositoryService) {
+  const repo = mockRepo ?? createMockNotificationRepositoryService();
+  return Layer.succeed(NotificationRepository, repo as unknown as NotificationRepositoryService);
+}
+
+// =============================================================================
+// Mock OrganizationRepository Service
+// =============================================================================
+
+import {
+  OrganizationRepository,
+  type OrganizationRepositoryService,
+} from "@/lib/effect/services/organization-repository";
+
+export interface MockOrganizationRepositoryService {
+  getOrganization: ReturnType<typeof vi.fn>;
+  getOrganizationBySlug: ReturnType<typeof vi.fn>;
+  getUserOrganizations: ReturnType<typeof vi.fn>;
+  createOrganization: ReturnType<typeof vi.fn>;
+  updateOrganization: ReturnType<typeof vi.fn>;
+  deleteOrganization: ReturnType<typeof vi.fn>;
+  getOrganizationMembers: ReturnType<typeof vi.fn>;
+  addMember: ReturnType<typeof vi.fn>;
+  removeMember: ReturnType<typeof vi.fn>;
+  updateMemberRole: ReturnType<typeof vi.fn>;
+}
+
+export function createMockOrganizationRepositoryService(): MockOrganizationRepositoryService {
+  const mockOrg = createMockOrganization();
+
+  return {
+    getOrganization: vi.fn().mockImplementation(() => Effect.succeed(mockOrg)),
+    getOrganizationBySlug: vi.fn().mockImplementation(() => Effect.succeed(mockOrg)),
+    getUserOrganizations: vi.fn().mockImplementation(() => Effect.succeed([mockOrg])),
+    createOrganization: vi.fn().mockImplementation((data) => Effect.succeed({ ...mockOrg, ...data })),
+    updateOrganization: vi.fn().mockImplementation((id, data) => Effect.succeed({ ...mockOrg, id, ...data })),
+    deleteOrganization: vi.fn().mockImplementation(() => Effect.void),
+    getOrganizationMembers: vi.fn().mockImplementation(() => Effect.succeed([])),
+    addMember: vi.fn().mockImplementation(() => Effect.succeed({})),
+    removeMember: vi.fn().mockImplementation(() => Effect.void),
+    updateMemberRole: vi.fn().mockImplementation(() => Effect.succeed({})),
+  };
+}
+
+export function createMockOrganizationRepositoryLayer(mockRepo?: MockOrganizationRepositoryService) {
+  const repo = mockRepo ?? createMockOrganizationRepositoryService();
+  return Layer.succeed(OrganizationRepository, repo as unknown as OrganizationRepositoryService);
+}
+
+// =============================================================================
+// Mock Auth Service
+// =============================================================================
+
+import { Auth, type AuthServiceInterface } from "@/lib/effect/services/auth";
+
+export interface MockAuthService {
+  getSession: ReturnType<typeof vi.fn>;
+  requireSession: ReturnType<typeof vi.fn>;
+  getCurrentUser: ReturnType<typeof vi.fn>;
+  requireUser: ReturnType<typeof vi.fn>;
+  requireOrganizationAccess: ReturnType<typeof vi.fn>;
+}
+
+export function createMockAuthService(user?: User): MockAuthService {
+  const mockUser = user ?? createMockUser();
+  const mockSession = { user: mockUser, session: { id: "session-123" } };
+
+  return {
+    getSession: vi.fn().mockImplementation(() => Effect.succeed(mockSession)),
+    requireSession: vi.fn().mockImplementation(() => Effect.succeed(mockSession)),
+    getCurrentUser: vi.fn().mockImplementation(() => Effect.succeed(mockUser)),
+    requireUser: vi.fn().mockImplementation(() => Effect.succeed(mockUser)),
+    requireOrganizationAccess: vi.fn().mockImplementation(() => Effect.succeed(mockUser)),
+  };
+}
+
+export function createMockAuthLayer(mockAuth?: MockAuthService) {
+  const auth = mockAuth ?? createMockAuthService();
+  return Layer.succeed(Auth, auth as unknown as AuthServiceInterface);
+}
+
+// =============================================================================
+// Mock AI Service
+// =============================================================================
+
+import { AI, type AIServiceInterface } from "@/lib/effect/services/ai";
+
+export interface MockAIService {
+  generateVideoSummary: ReturnType<typeof vi.fn>;
+  generateVideoTags: ReturnType<typeof vi.fn>;
+  extractActionItems: ReturnType<typeof vi.fn>;
+  extractActionItemsWithTimestamps: ReturnType<typeof vi.fn>;
+  detectCodeSnippets: ReturnType<typeof vi.fn>;
+  generateChapters: ReturnType<typeof vi.fn>;
+  createSummaryStream: ReturnType<typeof vi.fn>;
+  analyzeTranscriptForInsights: ReturnType<typeof vi.fn>;
+}
+
+export function createMockAIService(): MockAIService {
+  return {
+    generateVideoSummary: vi.fn().mockImplementation(() => Effect.succeed("## Summary\nTest summary content")),
+    generateVideoTags: vi.fn().mockImplementation(() => Effect.succeed(["tag1", "tag2", "tag3"])),
+    extractActionItems: vi.fn().mockImplementation(() => Effect.succeed(["Action item 1", "Action item 2"])),
+    extractActionItemsWithTimestamps: vi
+      .fn()
+      .mockImplementation(() => Effect.succeed([{ text: "Action item 1", timestamp: 60, priority: "high" as const }])),
+    detectCodeSnippets: vi.fn().mockImplementation(() => Effect.succeed([])),
+    generateChapters: vi.fn().mockImplementation(() => Effect.succeed([])),
+    createSummaryStream: vi.fn(),
+    analyzeTranscriptForInsights: vi
+      .fn()
+      .mockImplementation(() => Effect.succeed({ topics: [], sentiment: "neutral" })),
+  };
+}
+
+export function createMockAILayer(mockAI?: MockAIService) {
+  const ai = mockAI ?? createMockAIService();
+  return Layer.succeed(AI, ai as unknown as AIServiceInterface);
+}
+
+// =============================================================================
+// Mock Stripe Service
+// =============================================================================
+
+import { type StripeService, StripeServiceTag } from "@/lib/effect/services/stripe";
+
+export interface MockStripeService {
+  createCustomer: ReturnType<typeof vi.fn>;
+  createCheckoutSession: ReturnType<typeof vi.fn>;
+  createPortalSession: ReturnType<typeof vi.fn>;
+  createSubscription: ReturnType<typeof vi.fn>;
+  cancelSubscription: ReturnType<typeof vi.fn>;
+  updateSubscription: ReturnType<typeof vi.fn>;
+  getSubscription: ReturnType<typeof vi.fn>;
+  verifyWebhookSignature: ReturnType<typeof vi.fn>;
+  isConfigured: boolean;
+}
+
+export function createMockStripeService(): MockStripeService {
+  return {
+    createCustomer: vi.fn().mockImplementation(() => Effect.succeed({ id: "cus_test123" })),
+    createCheckoutSession: vi
+      .fn()
+      .mockImplementation(() => Effect.succeed({ url: "https://checkout.stripe.com/test" })),
+    createPortalSession: vi.fn().mockImplementation(() => Effect.succeed({ url: "https://portal.stripe.com/test" })),
+    createSubscription: vi.fn().mockImplementation(() => Effect.succeed({ id: "sub_test123", status: "active" })),
+    cancelSubscription: vi.fn().mockImplementation(() => Effect.succeed({ id: "sub_test123", status: "canceled" })),
+    updateSubscription: vi.fn().mockImplementation(() => Effect.succeed({ id: "sub_test123", status: "active" })),
+    getSubscription: vi.fn().mockImplementation(() => Effect.succeed({ id: "sub_test123", status: "active" })),
+    verifyWebhookSignature: vi.fn().mockImplementation(() => Effect.succeed({ type: "customer.subscription.updated" })),
+    isConfigured: true,
+  };
+}
+
+export function createMockStripeLayer(mockStripe?: MockStripeService) {
+  const stripe = mockStripe ?? createMockStripeService();
+  return Layer.succeed(StripeServiceTag, stripe as unknown as StripeService);
+}
+
+// =============================================================================
+// Test Data Factories
+// =============================================================================
+
+export function createMockVideoWithFullAuthor(
+  videoOverrides: Partial<Video> = {},
+  userOverrides: Partial<User> = {},
+): VideoWithAuthor {
+  const video = createMockVideo(videoOverrides);
+  const author = createMockUser(userOverrides);
+  return {
+    ...video,
+    deletedAt: null,
+    retentionUntil: null,
+    author,
+  } as VideoWithAuthor;
+}
+
+export function createMockCommentWithAuthor(
+  commentOverrides: Partial<Comment> = {},
+  userOverrides: Partial<User> = {},
+): CommentWithAuthor {
+  const author = createMockUser(userOverrides);
+  return {
+    id: "comment-123",
+    content: "Test comment content",
+    timestamp: "00:01:30",
+    authorId: author.id,
+    videoId: "video-123",
+    parentId: null,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    author,
+    ...commentOverrides,
+  } as CommentWithAuthor;
+}
+
+export function createMockCommentWithReplies(
+  commentOverrides: Partial<Comment> = {},
+  replies: CommentWithAuthor[] = [],
+): CommentWithReplies {
+  return {
+    ...createMockCommentWithAuthor(commentOverrides),
+    replies,
+  } as CommentWithReplies;
+}
+
+export function createMockNotification(overrides: Record<string, unknown> = {}): NotificationWithActor {
+  return {
+    id: "notification-123",
+    type: "comment" as const,
+    title: "New Comment",
+    message: "Someone commented on your video",
+    read: false,
+    userId: "user-123",
+    videoId: "video-123",
+    commentId: "comment-123",
+    createdAt: new Date("2024-01-01"),
+    video: null,
+    comment: null,
+    fromUser: null,
+    ...overrides,
+  } as unknown as NotificationWithActor;
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+/**
+ * Helper to run an Effect with a test layer and return the result
+ */
+export async function runWithLayer<A, E, R>(effect: Effect.Effect<A, E, R>, layer: Layer.Layer<R>): Promise<A> {
+  return Effect.runPromise(Effect.provide(effect, layer));
+}
+
+/**
+ * Helper to run an Effect with a test layer and return the Exit
+ */
+export async function runWithLayerExit<A, E, R>(effect: Effect.Effect<A, E, R>, layer: Layer.Layer<R>) {
+  return Effect.runPromiseExit(Effect.provide(effect, layer));
+}
+
+/**
+ * Creates a failure Effect for testing error handling
+ */
+export function createDatabaseError(message = "Database error") {
+  return new DatabaseError({ message, operation: "test" });
+}
+
+export function createNotFoundError(entity: string, id: string) {
+  return new NotFoundError({ message: `${entity} not found`, entity, id });
+}
+
+export function createDeleteError(message = "Delete failed") {
+  return new DeleteError({ message });
+}


### PR DESCRIPTION
- Create reusable test utilities in effect-test-utils.ts with mock layers for Database, Storage, VideoRepository, CommentRepository, NotificationRepository, OrganizationRepository, Auth, AI, and Stripe
- Add 141 tests covering Effect-TS services using dependency injection patterns to mock service dependencies
- Test coverage includes error handling, authorization, and edge cases for VideoRepository, CommentRepository, NotificationRepository, Storage, Stripe, and Auth services