### PR TITLE
Implement semantic search for concept discovery

### DIFF
--- a/docs/internal/architecture/database.md
+++ b/docs/internal/architecture/database.md
@@ -599,6 +599,60 @@ CREATE TABLE decision_edits (
 );
 ```
 
+## Semantic Search Tables
+
+Semantic search enables finding content by meaning rather than exact keywords. See [semantic-search.md](./semantic-search.md) for full documentation.
+
+### transcript_chunks Table
+
+Stores chunked transcript segments with vector embeddings for semantic search.
+
+```sql
+CREATE TABLE transcript_chunks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    video_id TEXT NOT NULL REFERENCES videos(id) ON DELETE CASCADE,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    token_count INTEGER,
+    timestamp_start INTEGER,  -- seconds into video
+    timestamp_end INTEGER,
+    speakers TEXT[],
+    embedding vector(1536),   -- OpenAI text-embedding-3-small
+    created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+    UNIQUE(video_id, chunk_index)
+);
+
+-- HNSW index for fast similarity search
+CREATE INDEX transcript_chunks_embedding_idx
+    ON transcript_chunks
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+```
+
+**Key Features:**
+
+- Vector embeddings for semantic similarity search
+- Timestamp mapping for video context
+- HNSW index for sub-linear search time
+- Organization isolation for multi-tenancy
+
+### pgvector Extension
+
+The semantic search functionality uses PostgreSQL's pgvector extension:
+
+```sql
+-- Enable vector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+### Embedding Columns
+
+Additional embedding columns exist on related tables:
+
+- `decisions.embedding_vector vector(1536)` - Semantic search for decisions
+- `knowledge_nodes.embedding_vector vector(1536)` - Knowledge graph semantic search
+
 ## Future Enhancements
 
 ### Scaling Considerations
@@ -610,6 +664,8 @@ CREATE TABLE decision_edits (
 ### Advanced Features
 
 - **Full-Text Search**: PostgreSQL full-text search
+- **Semantic Search**: Vector-based similarity search with pgvector
+- **Hybrid Search**: Combined keyword and semantic ranking
 - **JSON Columns**: Flexible metadata storage
 - **Triggers**: Automated data processing
 - **Views**: Simplified query interfaces

--- a/docs/internal/architecture/semantic-search.md
+++ b/docs/internal/architecture/semantic-search.md
@@ -1,0 +1,219 @@
+# Semantic Search Architecture
+
+This document describes the semantic search capabilities in Nuclom, enabling teams to find content by meaning rather than exact keyword matches.
+
+## Overview
+
+Semantic search uses vector embeddings to find content that is conceptually similar to a query, even when the exact words don't match. For example, searching for "database scaling discussions" will find videos mentioning "PostgreSQL performance", "sharding", "read replicas", etc.
+
+## Architecture
+
+### Components
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Search Flow                              │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  User Query ─────► Embedding ─────► Vector Search           │
+│      │             Service          (pgvector)               │
+│      │                                  │                    │
+│      │                                  ▼                    │
+│      └────────────────────────────► Full-text ◄───┐         │
+│                                     Search        │         │
+│                                        │          │         │
+│                                        ▼          │         │
+│                                   Hybrid Merge ───┘         │
+│                                        │                    │
+│                                        ▼                    │
+│                                   Ranked Results            │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Database Schema
+
+#### transcript_chunks Table
+Stores chunked transcript segments with vector embeddings:
+
+```sql
+CREATE TABLE transcript_chunks (
+  id UUID PRIMARY KEY,
+  video_id TEXT REFERENCES videos(id),
+  organization_id TEXT REFERENCES organizations(id),
+  chunk_index INTEGER,
+  text TEXT NOT NULL,
+  token_count INTEGER,
+  timestamp_start INTEGER,  -- seconds into video
+  timestamp_end INTEGER,
+  speakers TEXT[],
+  embedding vector(1536),   -- OpenAI text-embedding-3-small
+  created_at TIMESTAMP
+);
+```
+
+#### Vector Indexes
+HNSW indexes for fast approximate nearest neighbor search:
+
+```sql
+CREATE INDEX transcript_chunks_embedding_idx
+  ON transcript_chunks
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+```
+
+### Embedding Pipeline
+
+1. **Chunking**: Transcripts are split into ~500 token chunks with overlap
+2. **Embedding Generation**: OpenAI `text-embedding-3-small` (1536 dimensions)
+3. **Storage**: Embeddings stored as `vector(1536)` in PostgreSQL with pgvector
+4. **Indexing**: HNSW index for sub-linear search time
+
+## API Endpoints
+
+### Semantic Search
+```http
+POST /api/search/semantic
+{
+  "query": "discussions about database scaling",
+  "organizationId": "org_123",
+  "limit": 20,
+  "threshold": 0.7,
+  "contentTypes": ["transcript_chunk", "decision"]
+}
+```
+
+### Hybrid Search
+Combines semantic and keyword search with configurable weights:
+
+```http
+POST /api/search/hybrid
+{
+  "query": "PostgreSQL performance",
+  "organizationId": "org_123",
+  "semanticWeight": 0.5,  // 0-1, default 0.5
+  "semanticThreshold": 0.6
+}
+```
+
+### Similar Videos
+Find videos with similar content:
+
+```http
+GET /api/videos/{videoId}/similar?limit=5&threshold=0.7
+```
+
+### Generate Embeddings
+Trigger embedding generation for a video:
+
+```http
+POST /api/videos/{videoId}/embeddings
+```
+
+## Services
+
+### Embedding Service
+`src/lib/effect/services/embedding.ts`
+
+```typescript
+interface EmbeddingServiceInterface {
+  generateEmbedding(text: string): Effect<readonly number[], AIServiceError>;
+  generateEmbeddings(texts: readonly string[]): Effect<readonly number[][], AIServiceError>;
+  chunkTranscript(transcript: string, segments?: TranscriptSegment[]): Effect<TextChunk[], never>;
+  processTranscript(transcript: string, segments?: TranscriptSegment[]): Effect<ChunkEmbedding[], AIServiceError>;
+}
+```
+
+### Semantic Search Repository
+`src/lib/effect/services/semantic-search-repository.ts`
+
+```typescript
+interface SemanticSearchRepositoryService {
+  saveTranscriptChunks(videoId: string, organizationId: string, chunks: ChunkEmbedding[]): Effect<TranscriptChunk[], DatabaseError>;
+  semanticSearch(params: SemanticSearchParams): Effect<SemanticSearchResult[], DatabaseError>;
+  findSimilarVideos(params: SimilarVideosParams): Effect<SimilarVideoResult[], DatabaseError>;
+}
+```
+
+## Search Types
+
+### Pure Semantic Search
+Best for conceptual queries:
+- "discussions about authentication"
+- "how we handle error handling"
+- "performance optimization strategies"
+
+### Pure Keyword Search
+Best for exact term searches:
+- Specific error messages
+- Code snippets
+- Exact phrases
+
+### Hybrid Search
+Best for most use cases - combines both approaches:
+- Natural language questions
+- Technical topic exploration
+- Documentation search
+
+## Configuration
+
+### Similarity Threshold
+Default: 0.7 (70% similarity)
+- Higher = More relevant but fewer results
+- Lower = More results but less precise
+
+### Semantic Weight (Hybrid Search)
+Default: 0.5 (50/50 blend)
+- 1.0 = Pure semantic
+- 0.0 = Pure keyword
+
+## Chunking Strategy
+
+Transcripts are chunked using an overlapping window approach:
+- **Max tokens**: 500 per chunk
+- **Overlap**: 50 tokens between chunks
+- **Segment-aware**: Uses transcript segments when available for accurate timestamps
+
+## Integration Points
+
+### Video Processing
+Embeddings are generated automatically when:
+- A video transcript is completed
+- Manual trigger via `/api/videos/{videoId}/embeddings`
+
+### Knowledge Graph
+Decisions table has embedding fields for semantic search across decisions:
+- `decisions.embedding_vector` - vector(1536)
+- `knowledge_nodes.embedding_vector` - vector(1536)
+
+### Decision Extraction
+When decisions are extracted from videos, embeddings can be generated for semantic retrieval of organizational decisions.
+
+## Performance Considerations
+
+### Index Configuration
+HNSW parameters for ~1M vectors:
+- `m = 16` - connections per node (balance of recall vs speed)
+- `ef_construction = 64` - construction time quality
+
+### Query Optimization
+- Vector similarity uses cosine distance
+- Combined with filtering on organization_id for multi-tenancy
+- Results limited by threshold before final ranking
+
+### Backfill
+For existing videos without embeddings:
+```bash
+# API endpoint to get videos needing embeddings
+GET /api/videos/embeddings/pending?organizationId=org_123
+
+# Process each video
+POST /api/videos/{videoId}/embeddings
+```
+
+## Future Enhancements
+
+1. **Topic Clustering**: Group videos by semantic similarity
+2. **Auto-tagging**: Generate tags from embedding clusters
+3. **Cross-video Q&A**: Answer questions across all team videos
+4. **Timeline Search**: Find specific moments by semantic query

--- a/drizzle/0007_semantic_search.sql
+++ b/drizzle/0007_semantic_search.sql
@@ -1,0 +1,166 @@
+-- Migration: Enable pgvector and add transcript chunks for semantic search
+-- This migration adds vector-based semantic search capabilities
+
+-- Enable the pgvector extension for vector similarity search
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Create transcript_chunks table for storing embeddings of transcript segments
+-- Each video's transcript is chunked into ~500 token segments for better semantic search
+CREATE TABLE transcript_chunks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  video_id TEXT NOT NULL REFERENCES videos(id) ON DELETE CASCADE,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  token_count INTEGER,
+  timestamp_start INTEGER, -- seconds into video
+  timestamp_end INTEGER,   -- seconds into video
+  speakers TEXT[],         -- speaker names if available from diarization
+  embedding vector(1536),  -- OpenAI text-embedding-3-small dimension
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+
+  -- Ensure unique chunk index per video
+  CONSTRAINT transcript_chunks_unique_index UNIQUE (video_id, chunk_index)
+);
+
+-- Create HNSW index for fast approximate nearest neighbor search
+-- HNSW (Hierarchical Navigable Small World) provides excellent performance for high-dimensional vectors
+CREATE INDEX transcript_chunks_embedding_idx
+  ON transcript_chunks
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- Create indexes for filtering and lookup
+CREATE INDEX transcript_chunks_video_idx ON transcript_chunks(video_id);
+CREATE INDEX transcript_chunks_org_idx ON transcript_chunks(organization_id);
+CREATE INDEX transcript_chunks_created_idx ON transcript_chunks(created_at);
+
+-- Add vector embedding column to decisions table (migrate from JSONB to vector)
+-- First add the new vector column
+ALTER TABLE decisions ADD COLUMN embedding_vector vector(1536);
+
+-- Migrate existing JSONB embeddings to vector format
+UPDATE decisions
+SET embedding_vector = embedding::text::vector
+WHERE embedding IS NOT NULL
+  AND jsonb_array_length(embedding) = 1536;
+
+-- Add vector embedding column to knowledge_nodes table
+ALTER TABLE knowledge_nodes ADD COLUMN embedding_vector vector(1536);
+
+-- Migrate existing JSONB embeddings to vector format
+UPDATE knowledge_nodes
+SET embedding_vector = embedding::text::vector
+WHERE embedding IS NOT NULL
+  AND jsonb_array_length(embedding) = 1536;
+
+-- Create HNSW indexes for decisions and knowledge_nodes
+CREATE INDEX decisions_embedding_idx
+  ON decisions
+  USING hnsw (embedding_vector vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+CREATE INDEX knowledge_nodes_embedding_idx
+  ON knowledge_nodes
+  USING hnsw (embedding_vector vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- Create a helper function for semantic search across all content types
+CREATE OR REPLACE FUNCTION semantic_search(
+  query_embedding vector(1536),
+  org_id TEXT,
+  similarity_threshold FLOAT DEFAULT 0.7,
+  max_results INTEGER DEFAULT 20
+)
+RETURNS TABLE (
+  content_type TEXT,
+  content_id TEXT,
+  video_id TEXT,
+  similarity FLOAT,
+  text_preview TEXT,
+  timestamp_start INTEGER,
+  timestamp_end INTEGER
+) AS $$
+BEGIN
+  RETURN QUERY
+  -- Search transcript chunks
+  SELECT
+    'transcript_chunk'::TEXT as content_type,
+    tc.id::TEXT as content_id,
+    tc.video_id::TEXT,
+    1 - (tc.embedding <=> query_embedding) as similarity,
+    LEFT(tc.text, 500) as text_preview,
+    tc.timestamp_start,
+    tc.timestamp_end
+  FROM transcript_chunks tc
+  WHERE tc.organization_id = org_id
+    AND tc.embedding IS NOT NULL
+    AND 1 - (tc.embedding <=> query_embedding) >= similarity_threshold
+
+  UNION ALL
+
+  -- Search decisions
+  SELECT
+    'decision'::TEXT as content_type,
+    d.id::TEXT as content_id,
+    d.video_id::TEXT,
+    1 - (d.embedding_vector <=> query_embedding) as similarity,
+    LEFT(d.summary, 500) as text_preview,
+    d.timestamp_start,
+    d.timestamp_end
+  FROM decisions d
+  WHERE d.organization_id = org_id
+    AND d.embedding_vector IS NOT NULL
+    AND 1 - (d.embedding_vector <=> query_embedding) >= similarity_threshold
+
+  ORDER BY similarity DESC
+  LIMIT max_results;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Create a function to find similar videos based on transcript embeddings
+CREATE OR REPLACE FUNCTION find_similar_videos(
+  source_video_id TEXT,
+  org_id TEXT,
+  max_results INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+  video_id TEXT,
+  similarity FLOAT,
+  matching_chunks INTEGER
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH source_embeddings AS (
+    SELECT embedding
+    FROM transcript_chunks
+    WHERE video_id = source_video_id
+      AND embedding IS NOT NULL
+  ),
+  chunk_similarities AS (
+    SELECT
+      tc.video_id,
+      MAX(1 - (tc.embedding <=> se.embedding)) as max_similarity
+    FROM transcript_chunks tc
+    CROSS JOIN source_embeddings se
+    WHERE tc.organization_id = org_id
+      AND tc.video_id != source_video_id
+      AND tc.embedding IS NOT NULL
+    GROUP BY tc.video_id, tc.id
+  )
+  SELECT
+    cs.video_id,
+    AVG(cs.max_similarity)::FLOAT as similarity,
+    COUNT(*)::INTEGER as matching_chunks
+  FROM chunk_similarities cs
+  GROUP BY cs.video_id
+  HAVING AVG(cs.max_similarity) > 0.7
+  ORDER BY similarity DESC
+  LIMIT max_results;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Add comment for documentation
+COMMENT ON TABLE transcript_chunks IS 'Stores chunked transcript segments with vector embeddings for semantic search';
+COMMENT ON FUNCTION semantic_search IS 'Performs semantic similarity search across transcript chunks and decisions';
+COMMENT ON FUNCTION find_similar_videos IS 'Finds videos with similar content based on transcript embeddings';

--- a/src/app/api/search/hybrid/route.ts
+++ b/src/app/api/search/hybrid/route.ts
@@ -1,0 +1,355 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { connection } from "next/server";
+import { createFullLayer, handleEffectExit } from "@/lib/api-handler";
+import type { SearchFilters } from "@/lib/db/schema";
+import { MissingFieldError, SearchRepository } from "@/lib/effect";
+import { Auth } from "@/lib/effect/services/auth";
+import { Embedding } from "@/lib/effect/services/embedding";
+import { SemanticSearchRepository } from "@/lib/effect/services/semantic-search-repository";
+import type { VideoWithAuthor } from "@/lib/types";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface HybridSearchResult {
+  video: VideoWithAuthor;
+  keywordScore: number;
+  semanticScore: number;
+  combinedScore: number;
+  highlights?: {
+    title?: string;
+    description?: string;
+    transcript?: string;
+  };
+  semanticMatch?: {
+    contentType: "transcript_chunk" | "decision";
+    textPreview: string;
+    timestampStart?: number;
+    timestampEnd?: number;
+  };
+}
+
+// =============================================================================
+// POST /api/search/hybrid - Hybrid search combining keyword and semantic
+// =============================================================================
+
+export async function POST(request: NextRequest) {
+  await connection();
+
+  // Parse request body outside of Effect
+  const body = (await request.json()) as {
+    query?: string;
+    organizationId?: string;
+    filters?: SearchFilters;
+    page?: number;
+    limit?: number;
+    semanticWeight?: number; // 0-1, how much to weight semantic vs keyword
+    semanticThreshold?: number;
+  };
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    const { user } = yield* authService.getSession(request.headers);
+
+    const {
+      query,
+      organizationId,
+      filters,
+      page = 1,
+      limit = 20,
+      semanticWeight = 0.5, // Default 50/50 blend
+      semanticThreshold = 0.6,
+    } = body;
+
+    if (!query || !query.trim()) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "query",
+          message: "Search query is required",
+        }),
+      );
+    }
+
+    if (!organizationId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "organizationId",
+          message: "Organization ID is required",
+        }),
+      );
+    }
+
+    const keywordWeight = 1 - semanticWeight;
+
+    // Run keyword search and semantic search in parallel
+    const searchRepo = yield* SearchRepository;
+    const embeddingService = yield* Embedding;
+    const semanticSearchRepo = yield* SemanticSearchRepository;
+
+    // Generate query embedding
+    const queryEmbedding = yield* embeddingService.generateEmbedding(query.trim());
+
+    // Run both searches in parallel
+    const [keywordResults, semanticResults] = yield* Effect.all([
+      searchRepo.search({
+        query: query.trim(),
+        organizationId,
+        filters,
+        page: 1,
+        limit: limit * 2, // Get more results to merge
+      }),
+      semanticSearchRepo.semanticSearchWithVideos({
+        queryEmbedding,
+        organizationId,
+        limit: limit * 2,
+        threshold: semanticThreshold,
+      }),
+    ]);
+
+    // Create a map to merge results by video ID
+    const videoMap = new Map<string, HybridSearchResult>();
+
+    // Process keyword results
+    for (const result of keywordResults.results) {
+      const normalizedKeywordScore = result.rank / (keywordResults.results[0]?.rank || 1);
+      videoMap.set(result.video.id, {
+        video: result.video,
+        keywordScore: normalizedKeywordScore,
+        semanticScore: 0,
+        combinedScore: normalizedKeywordScore * keywordWeight,
+        highlights: result.highlights,
+      });
+    }
+
+    // Process semantic results
+    for (const result of semanticResults) {
+      const existing = videoMap.get(result.videoId);
+
+      if (existing) {
+        // Merge with existing keyword result
+        existing.semanticScore = result.similarity;
+        existing.combinedScore = existing.keywordScore * keywordWeight + result.similarity * semanticWeight;
+        existing.semanticMatch = {
+          contentType: result.contentType,
+          textPreview: result.textPreview,
+          timestampStart: result.timestampStart,
+          timestampEnd: result.timestampEnd,
+        };
+      } else if (result.video) {
+        // New video from semantic search only
+        videoMap.set(result.videoId, {
+          video: result.video,
+          keywordScore: 0,
+          semanticScore: result.similarity,
+          combinedScore: result.similarity * semanticWeight,
+          semanticMatch: {
+            contentType: result.contentType,
+            textPreview: result.textPreview,
+            timestampStart: result.timestampStart,
+            timestampEnd: result.timestampEnd,
+          },
+        });
+      }
+    }
+
+    // Sort by combined score and paginate
+    const allResults = Array.from(videoMap.values()).sort((a, b) => b.combinedScore - a.combinedScore);
+
+    const offset = (page - 1) * limit;
+    const paginatedResults = allResults.slice(offset, offset + limit);
+
+    // Save search to history
+    yield* searchRepo
+      .saveSearchHistory({
+        userId: user.id,
+        organizationId,
+        query: query.trim(),
+        filters,
+        resultsCount: allResults.length,
+      })
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+    return {
+      results: paginatedResults,
+      query: query.trim(),
+      total: allResults.length,
+      pagination: {
+        page,
+        limit,
+        totalPages: Math.ceil(allResults.length / limit),
+      },
+      searchMode: "hybrid",
+      weights: {
+        keyword: keywordWeight,
+        semantic: semanticWeight,
+      },
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}
+
+// =============================================================================
+// GET /api/search/hybrid - Hybrid search via query params
+// =============================================================================
+
+export async function GET(request: NextRequest) {
+  await connection();
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    const { user } = yield* authService.getSession(request.headers);
+
+    // Parse query params
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get("q") || "";
+    const organizationId = searchParams.get("organizationId");
+    const page = parseInt(searchParams.get("page") || "1", 10);
+    const limit = Math.min(parseInt(searchParams.get("limit") || "20", 10), 100);
+    const semanticWeight = parseFloat(searchParams.get("semanticWeight") || "0.5");
+    const semanticThreshold = parseFloat(searchParams.get("threshold") || "0.6");
+
+    // Parse filters
+    const authorId = searchParams.get("authorId");
+    const channelId = searchParams.get("channelId");
+    const collectionId = searchParams.get("collectionId");
+    const processingStatus = searchParams.get("processingStatus");
+    const dateFrom = searchParams.get("dateFrom");
+    const dateTo = searchParams.get("dateTo");
+
+    const filters: SearchFilters = {
+      ...(authorId && { authorId }),
+      ...(channelId && { channelId }),
+      ...(collectionId && { collectionId }),
+      ...(processingStatus && { processingStatus }),
+      ...(dateFrom && { dateFrom }),
+      ...(dateTo && { dateTo }),
+    };
+
+    if (!query.trim()) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "q",
+          message: "Search query is required",
+        }),
+      );
+    }
+
+    if (!organizationId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "organizationId",
+          message: "Organization ID is required",
+        }),
+      );
+    }
+
+    const keywordWeight = 1 - semanticWeight;
+
+    // Run both searches
+    const searchRepo = yield* SearchRepository;
+    const embeddingService = yield* Embedding;
+    const semanticSearchRepo = yield* SemanticSearchRepository;
+
+    const queryEmbedding = yield* embeddingService.generateEmbedding(query.trim());
+
+    const [keywordResults, semanticResults] = yield* Effect.all([
+      searchRepo.search({
+        query: query.trim(),
+        organizationId,
+        filters: Object.keys(filters).length > 0 ? filters : undefined,
+        page: 1,
+        limit: limit * 2,
+      }),
+      semanticSearchRepo.semanticSearchWithVideos({
+        queryEmbedding,
+        organizationId,
+        limit: limit * 2,
+        threshold: semanticThreshold,
+      }),
+    ]);
+
+    // Merge results
+    const videoMap = new Map<string, HybridSearchResult>();
+
+    for (const result of keywordResults.results) {
+      const normalizedKeywordScore = result.rank / (keywordResults.results[0]?.rank || 1);
+      videoMap.set(result.video.id, {
+        video: result.video,
+        keywordScore: normalizedKeywordScore,
+        semanticScore: 0,
+        combinedScore: normalizedKeywordScore * keywordWeight,
+        highlights: result.highlights,
+      });
+    }
+
+    for (const result of semanticResults) {
+      const existing = videoMap.get(result.videoId);
+
+      if (existing) {
+        existing.semanticScore = result.similarity;
+        existing.combinedScore = existing.keywordScore * keywordWeight + result.similarity * semanticWeight;
+        existing.semanticMatch = {
+          contentType: result.contentType,
+          textPreview: result.textPreview,
+          timestampStart: result.timestampStart,
+          timestampEnd: result.timestampEnd,
+        };
+      } else if (result.video) {
+        videoMap.set(result.videoId, {
+          video: result.video,
+          keywordScore: 0,
+          semanticScore: result.similarity,
+          combinedScore: result.similarity * semanticWeight,
+          semanticMatch: {
+            contentType: result.contentType,
+            textPreview: result.textPreview,
+            timestampStart: result.timestampStart,
+            timestampEnd: result.timestampEnd,
+          },
+        });
+      }
+    }
+
+    const allResults = Array.from(videoMap.values()).sort((a, b) => b.combinedScore - a.combinedScore);
+    const offset = (page - 1) * limit;
+    const paginatedResults = allResults.slice(offset, offset + limit);
+
+    // Save search to history
+    yield* searchRepo
+      .saveSearchHistory({
+        userId: user.id,
+        organizationId,
+        query: query.trim(),
+        filters: Object.keys(filters).length > 0 ? filters : undefined,
+        resultsCount: allResults.length,
+      })
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+    return {
+      results: paginatedResults,
+      query: query.trim(),
+      total: allResults.length,
+      pagination: {
+        page,
+        limit,
+        totalPages: Math.ceil(allResults.length / limit),
+      },
+      searchMode: "hybrid",
+      weights: {
+        keyword: keywordWeight,
+        semantic: semanticWeight,
+      },
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -1,0 +1,142 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { connection } from "next/server";
+import { createFullLayer, handleEffectExit } from "@/lib/api-handler";
+import { MissingFieldError } from "@/lib/effect";
+import { Auth } from "@/lib/effect/services/auth";
+import { Embedding } from "@/lib/effect/services/embedding";
+import { SemanticSearchRepository } from "@/lib/effect/services/semantic-search-repository";
+
+// =============================================================================
+// POST /api/search/semantic - Semantic search using embeddings
+// =============================================================================
+
+export async function POST(request: NextRequest) {
+  await connection();
+
+  // Parse request body outside of Effect
+  const body = (await request.json()) as {
+    query?: string;
+    organizationId?: string;
+    limit?: number;
+    threshold?: number;
+    contentTypes?: ("transcript_chunk" | "decision")[];
+    videoIds?: string[];
+    channelIds?: string[];
+  };
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    yield* authService.getSession(request.headers);
+
+    const { query, organizationId, limit = 20, threshold = 0.7, contentTypes, videoIds, channelIds } = body;
+
+    if (!query || !query.trim()) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "query",
+          message: "Search query is required",
+        }),
+      );
+    }
+
+    if (!organizationId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "organizationId",
+          message: "Organization ID is required",
+        }),
+      );
+    }
+
+    // Generate embedding for the query
+    const embeddingService = yield* Embedding;
+    const queryEmbedding = yield* embeddingService.generateEmbedding(query.trim());
+
+    // Perform semantic search
+    const searchRepo = yield* SemanticSearchRepository;
+    const results = yield* searchRepo.semanticSearchWithVideos({
+      queryEmbedding,
+      organizationId,
+      limit,
+      threshold,
+      contentTypes,
+      videoIds,
+    });
+
+    return {
+      results,
+      query: query.trim(),
+      total: results.length,
+      threshold,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}
+
+// =============================================================================
+// GET /api/search/semantic - Simple semantic search via query params
+// =============================================================================
+
+export async function GET(request: NextRequest) {
+  await connection();
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    yield* authService.getSession(request.headers);
+
+    // Parse query params
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get("q") || "";
+    const organizationId = searchParams.get("organizationId");
+    const limit = Math.min(parseInt(searchParams.get("limit") || "20", 10), 100);
+    const threshold = parseFloat(searchParams.get("threshold") || "0.7");
+
+    if (!query.trim()) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "q",
+          message: "Search query is required",
+        }),
+      );
+    }
+
+    if (!organizationId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "organizationId",
+          message: "Organization ID is required",
+        }),
+      );
+    }
+
+    // Generate embedding for the query
+    const embeddingService = yield* Embedding;
+    const queryEmbedding = yield* embeddingService.generateEmbedding(query.trim());
+
+    // Perform semantic search
+    const searchRepo = yield* SemanticSearchRepository;
+    const results = yield* searchRepo.semanticSearchWithVideos({
+      queryEmbedding,
+      organizationId,
+      limit,
+      threshold,
+    });
+
+    return {
+      results,
+      query: query.trim(),
+      total: results.length,
+      threshold,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}

--- a/src/app/api/videos/[videoId]/embeddings/route.ts
+++ b/src/app/api/videos/[videoId]/embeddings/route.ts
@@ -1,0 +1,158 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { connection } from "next/server";
+import { createFullLayer, handleEffectExit, handleEffectExitWithStatus } from "@/lib/api-handler";
+import { getVideo, MissingFieldError, ValidationError } from "@/lib/effect";
+import { Auth } from "@/lib/effect/services/auth";
+import { Embedding } from "@/lib/effect/services/embedding";
+import { SemanticSearchRepository } from "@/lib/effect/services/semantic-search-repository";
+
+// =============================================================================
+// GET /api/videos/[videoId]/embeddings - Get embedding status for a video
+// =============================================================================
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ videoId: string }> }) {
+  await connection();
+
+  const { videoId } = await params;
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    yield* authService.getSession(request.headers);
+
+    if (!videoId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "videoId",
+          message: "Video ID is required",
+        }),
+      );
+    }
+
+    // Check if video has embeddings
+    const searchRepo = yield* SemanticSearchRepository;
+    const hasEmbeddings = yield* searchRepo.hasEmbeddings(videoId);
+    const chunks = yield* searchRepo.getTranscriptChunks(videoId);
+
+    return {
+      videoId,
+      hasEmbeddings,
+      chunkCount: chunks.length,
+      chunks: chunks.map((c) => ({
+        id: c.id,
+        chunkIndex: c.chunkIndex,
+        tokenCount: c.tokenCount,
+        timestampStart: c.timestampStart,
+        timestampEnd: c.timestampEnd,
+        textPreview: c.text.substring(0, 200) + (c.text.length > 200 ? "..." : ""),
+      })),
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}
+
+// =============================================================================
+// POST /api/videos/[videoId]/embeddings - Generate embeddings for a video
+// =============================================================================
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ videoId: string }> }) {
+  await connection();
+
+  const { videoId } = await params;
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    yield* authService.getSession(request.headers);
+
+    if (!videoId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "videoId",
+          message: "Video ID is required",
+        }),
+      );
+    }
+
+    // Get the video
+    const video = yield* getVideo(videoId);
+
+    // Verify video has a transcript
+    if (!video.transcript) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: "Video does not have a transcript. Please wait for processing to complete.",
+          field: "transcript",
+        }),
+      );
+    }
+
+    // Generate embeddings
+    const embeddingService = yield* Embedding;
+    const chunkEmbeddings = yield* embeddingService.processTranscript(
+      video.transcript,
+      video.transcriptSegments || undefined,
+    );
+
+    // Save to database
+    const searchRepo = yield* SemanticSearchRepository;
+    const savedChunks = yield* searchRepo.saveTranscriptChunks(videoId, video.organizationId, chunkEmbeddings);
+
+    return {
+      videoId,
+      success: true,
+      chunksCreated: savedChunks.length,
+      message: `Generated embeddings for ${savedChunks.length} transcript chunks`,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExitWithStatus(exit, 201);
+}
+
+// =============================================================================
+// DELETE /api/videos/[videoId]/embeddings - Delete embeddings for a video
+// =============================================================================
+
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ videoId: string }> }) {
+  await connection();
+
+  const { videoId } = await params;
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    yield* authService.getSession(request.headers);
+
+    if (!videoId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "videoId",
+          message: "Video ID is required",
+        }),
+      );
+    }
+
+    // Verify video exists
+    yield* getVideo(videoId);
+
+    // Delete embeddings
+    const searchRepo = yield* SemanticSearchRepository;
+    yield* searchRepo.deleteTranscriptChunks(videoId);
+
+    return {
+      videoId,
+      success: true,
+      message: "Embeddings deleted successfully",
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}

--- a/src/app/api/videos/[videoId]/similar/route.ts
+++ b/src/app/api/videos/[videoId]/similar/route.ts
@@ -1,0 +1,60 @@
+import { Effect } from "effect";
+import type { NextRequest } from "next/server";
+import { connection } from "next/server";
+import { createFullLayer, handleEffectExit } from "@/lib/api-handler";
+import { getVideo, MissingFieldError } from "@/lib/effect";
+import { Auth } from "@/lib/effect/services/auth";
+import { SemanticSearchRepository } from "@/lib/effect/services/semantic-search-repository";
+
+// =============================================================================
+// GET /api/videos/[videoId]/similar - Find similar videos
+// =============================================================================
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ videoId: string }> }) {
+  await connection();
+
+  const { videoId } = await params;
+
+  const effect = Effect.gen(function* () {
+    // Authenticate
+    const authService = yield* Auth;
+    yield* authService.getSession(request.headers);
+
+    if (!videoId) {
+      return yield* Effect.fail(
+        new MissingFieldError({
+          field: "videoId",
+          message: "Video ID is required",
+        }),
+      );
+    }
+
+    // Parse query params
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") || "5", 10), 20);
+    const threshold = parseFloat(searchParams.get("threshold") || "0.7");
+
+    // Get video to verify it exists and get organizationId
+    const video = yield* getVideo(videoId);
+
+    // Find similar videos
+    const searchRepo = yield* SemanticSearchRepository;
+    const similarVideos = yield* searchRepo.findSimilarVideos({
+      videoId,
+      organizationId: video.organizationId,
+      limit,
+      threshold,
+    });
+
+    return {
+      videoId,
+      similarVideos,
+      total: similarVideos.length,
+      threshold,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createFullLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+  return handleEffectExit(exit);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1397,6 +1397,7 @@ export const videosRelations = relations(videos, ({ one, many }) => ({
   decisions: many(decisions),
   speakers: many(videoSpeakers),
   speakerSegments: many(speakerSegments),
+  transcriptChunks: many(transcriptChunks),
 }));
 
 export const videoChaptersRelations = relations(videoChapters, ({ one }) => ({
@@ -1879,6 +1880,42 @@ export const speakerAnalytics = pgTable(
       table.speakerProfileId,
       table.periodStart,
     ),
+  }),
+);
+
+// =====================
+// Transcript Chunks for Semantic Search
+// =====================
+
+// Stores chunked transcript segments with vector embeddings for semantic search
+// Each video's transcript is chunked into ~500 token segments for better semantic matching
+export const transcriptChunks = pgTable(
+  "transcript_chunks",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    videoId: text("video_id")
+      .notNull()
+      .references(() => videos.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    chunkIndex: integer("chunk_index").notNull(),
+    text: text("text").notNull(),
+    tokenCount: integer("token_count"),
+    timestampStart: integer("timestamp_start"), // seconds into video
+    timestampEnd: integer("timestamp_end"), // seconds into video
+    speakers: jsonb("speakers").$type<string[]>(), // speaker names if available
+    // Embedding stored as JSON array (compatible with pgvector via migration)
+    // The actual vector column is created in the migration
+    embedding: jsonb("embedding").$type<number[]>(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    videoIdx: index("transcript_chunks_video_idx").on(table.videoId),
+    orgIdx: index("transcript_chunks_org_idx").on(table.organizationId),
+    uniqueChunkIndex: unique("transcript_chunks_unique_index").on(table.videoId, table.chunkIndex),
   }),
 );
 
@@ -2499,6 +2536,18 @@ export const speakerAnalyticsRelations = relations(speakerAnalytics, ({ one }) =
   speakerProfile: one(speakerProfiles, {
     fields: [speakerAnalytics.speakerProfileId],
     references: [speakerProfiles.id],
+  }),
+}));
+
+// Transcript Chunks relations
+export const transcriptChunksRelations = relations(transcriptChunks, ({ one }) => ({
+  video: one(videos, {
+    fields: [transcriptChunks.videoId],
+    references: [videos.id],
+  }),
+  organization: one(organizations, {
+    fields: [transcriptChunks.organizationId],
+    references: [organizations.id],
   }),
 }));
 
@@ -3280,3 +3329,7 @@ export type HighlightReel = typeof highlightReels.$inferSelect;
 export type NewHighlightReel = typeof highlightReels.$inferInsert;
 export type QuoteCard = typeof quoteCards.$inferSelect;
 export type NewQuoteCard = typeof quoteCards.$inferInsert;
+
+// Semantic Search Types
+export type TranscriptChunk = typeof transcriptChunks.$inferSelect;
+export type NewTranscriptChunk = typeof transcriptChunks.$inferInsert;

--- a/src/lib/effect/runtime.ts
+++ b/src/lib/effect/runtime.ts
@@ -24,12 +24,14 @@ import { type CodeLinksRepository, CodeLinksRepositoryLive } from "./services/co
 import { type CommentRepository, CommentRepositoryLive } from "./services/comment-repository";
 import { type Database, DatabaseLive } from "./services/database";
 import { type EmailNotifications, EmailNotificationsLive } from "./services/email-notifications";
+import { type Embedding, EmbeddingLive } from "./services/embedding";
 import { type IntegrationRepository, IntegrationRepositoryLive } from "./services/integration-repository";
 import { type KnowledgeGraphRepository, KnowledgeGraphRepositoryLive } from "./services/knowledge-graph-repository";
 import { type NotificationRepository, NotificationRepositoryLive } from "./services/notification-repository";
 import { type OrganizationRepository, OrganizationRepositoryLive } from "./services/organization-repository";
 import { type ReplicateAPI, ReplicateLive } from "./services/replicate";
 import { type SearchRepository, SearchRepositoryLive } from "./services/search-repository";
+import { type SemanticSearchRepository, SemanticSearchRepositoryLive } from "./services/semantic-search-repository";
 import { type SeriesRepository, SeriesRepositoryLive } from "./services/series-repository";
 import { type SlackMonitoring, SlackMonitoringLive } from "./services/slack-monitoring";
 import { type Storage, StorageLive } from "./services/storage";
@@ -53,6 +55,7 @@ const BaseServicesLive = Layer.mergeAll(
   DatabaseLive,
   StorageLive,
   AILive,
+  EmbeddingLive,
   ReplicateLive,
   StripeServiceLive,
   TranslationLive,
@@ -79,6 +82,7 @@ const ChannelRepositoryWithDeps = ChannelRepositoryLive.pipe(Layer.provide(Datab
 const ClipRepositoryWithDeps = ClipRepositoryLive.pipe(Layer.provide(Layer.mergeAll(DatabaseLive, StorageLive)));
 const CodeLinksRepositoryWithDeps = CodeLinksRepositoryLive.pipe(Layer.provide(DatabaseLive));
 const KnowledgeGraphRepositoryWithDeps = KnowledgeGraphRepositoryLive.pipe(Layer.provide(DatabaseLive));
+const SemanticSearchRepositoryWithDeps = SemanticSearchRepositoryLive.pipe(Layer.provide(DatabaseLive));
 
 // Billing service depends on BillingRepository, StripeService, Database, and EmailNotifications
 const BillingWithDeps = BillingLive.pipe(
@@ -97,6 +101,7 @@ const AppServicesLive = Layer.mergeAll(
   BillingRepositoryWithDeps,
   BillingWithDeps,
   SearchRepositoryWithDeps,
+  SemanticSearchRepositoryWithDeps,
   SeriesRepositoryWithDeps,
   ChannelRepositoryWithDeps,
   ClipRepositoryWithDeps,
@@ -114,6 +119,7 @@ export type AppServices =
   | Database
   | Storage
   | AI
+  | Embedding
   | ReplicateAPI
   | VideoProcessor
   | VideoRepository
@@ -126,6 +132,7 @@ export type AppServices =
   | BillingRepository
   | Billing
   | SearchRepository
+  | SemanticSearchRepository
   | SeriesRepository
   | ChannelRepository
   | ClipRepository

--- a/src/lib/effect/services/embedding.ts
+++ b/src/lib/effect/services/embedding.ts
@@ -1,0 +1,389 @@
+/**
+ * Embedding Service using Effect-TS
+ *
+ * Provides type-safe embedding generation using OpenAI's text-embedding-3-small model.
+ * Embeddings are 1536-dimensional vectors used for semantic similarity search.
+ */
+
+import { gateway } from "@ai-sdk/gateway";
+import { embed, embedMany } from "ai";
+import { Context, Effect, Layer } from "effect";
+import type { TranscriptSegment } from "@/lib/db/schema";
+import { AIServiceError } from "../errors";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A single chunk of text with metadata for embedding
+ */
+export interface TextChunk {
+  readonly text: string;
+  readonly chunkIndex: number;
+  readonly timestampStart?: number;
+  readonly timestampEnd?: number;
+  readonly speakers?: readonly string[];
+  readonly tokenCount?: number;
+}
+
+/**
+ * Embedding result for a chunk
+ */
+export interface ChunkEmbedding {
+  readonly chunk: TextChunk;
+  readonly embedding: readonly number[];
+}
+
+/**
+ * Configuration for chunking
+ */
+export interface ChunkConfig {
+  readonly maxTokens?: number; // Default: 500
+  readonly overlapTokens?: number; // Default: 50
+}
+
+export interface EmbeddingServiceInterface {
+  /**
+   * Generate an embedding for a single text
+   */
+  readonly generateEmbedding: (text: string) => Effect.Effect<readonly number[], AIServiceError>;
+
+  /**
+   * Generate embeddings for multiple texts in batch
+   */
+  readonly generateEmbeddings: (
+    texts: readonly string[],
+  ) => Effect.Effect<readonly (readonly number[])[], AIServiceError>;
+
+  /**
+   * Chunk a transcript into segments suitable for embedding
+   */
+  readonly chunkTranscript: (
+    transcript: string,
+    segments?: readonly TranscriptSegment[],
+    config?: ChunkConfig,
+  ) => Effect.Effect<readonly TextChunk[], never>;
+
+  /**
+   * Generate embeddings for transcript chunks
+   */
+  readonly embedTranscriptChunks: (
+    chunks: readonly TextChunk[],
+  ) => Effect.Effect<readonly ChunkEmbedding[], AIServiceError>;
+
+  /**
+   * Chunk and embed a full transcript in one operation
+   */
+  readonly processTranscript: (
+    transcript: string,
+    segments?: readonly TranscriptSegment[],
+    config?: ChunkConfig,
+  ) => Effect.Effect<readonly ChunkEmbedding[], AIServiceError>;
+}
+
+// =============================================================================
+// Embedding Service Tag
+// =============================================================================
+
+export class Embedding extends Context.Tag("Embedding")<Embedding, EmbeddingServiceInterface>() {}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Estimate token count for a text string
+ * Using a rough approximation of 4 characters per token for English text
+ */
+const estimateTokenCount = (text: string): number => {
+  return Math.ceil(text.length / 4);
+};
+
+/**
+ * Split text into sentences (basic sentence boundary detection)
+ */
+const splitIntoSentences = (text: string): string[] => {
+  // Split on sentence boundaries while keeping the delimiter
+  return text.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 0);
+};
+
+// =============================================================================
+// Embedding Service Implementation
+// =============================================================================
+
+const makeEmbeddingService = Effect.gen(function* () {
+  const embeddingModel = gateway.textEmbeddingModel("text-embedding-3-small");
+
+  const generateEmbedding = (text: string): Effect.Effect<readonly number[], AIServiceError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const { embedding } = await embed({
+          model: embeddingModel,
+          value: text,
+        });
+        return embedding;
+      },
+      catch: (error) =>
+        new AIServiceError({
+          message: "Failed to generate embedding",
+          operation: "generateEmbedding",
+          cause: error,
+        }),
+    });
+
+  const generateEmbeddings = (
+    texts: readonly string[],
+  ): Effect.Effect<readonly (readonly number[])[], AIServiceError> =>
+    Effect.tryPromise({
+      try: async () => {
+        if (texts.length === 0) {
+          return [];
+        }
+
+        // Process in batches of 100 (OpenAI limit)
+        const batchSize = 100;
+        const allEmbeddings: number[][] = [];
+
+        for (let i = 0; i < texts.length; i += batchSize) {
+          const batch = texts.slice(i, i + batchSize);
+          const { embeddings } = await embedMany({
+            model: embeddingModel,
+            values: batch as string[],
+          });
+          allEmbeddings.push(...embeddings);
+        }
+
+        return allEmbeddings;
+      },
+      catch: (error) =>
+        new AIServiceError({
+          message: "Failed to generate embeddings batch",
+          operation: "generateEmbeddings",
+          cause: error,
+        }),
+    });
+
+  const chunkTranscript = (
+    transcript: string,
+    segments?: readonly TranscriptSegment[],
+    config?: ChunkConfig,
+  ): Effect.Effect<readonly TextChunk[], never> =>
+    Effect.sync(() => {
+      const maxTokens = config?.maxTokens ?? 500;
+      const overlapTokens = config?.overlapTokens ?? 50;
+      const chunks: TextChunk[] = [];
+
+      if (segments && segments.length > 0) {
+        // Use transcript segments for more accurate chunking with timestamps
+        let currentChunk: {
+          texts: string[];
+          startTime: number;
+          endTime: number;
+          speakers: Set<string>;
+          tokenCount: number;
+        } = {
+          texts: [],
+          startTime: segments[0].startTime,
+          endTime: segments[0].endTime,
+          speakers: new Set(),
+          tokenCount: 0,
+        };
+
+        for (const segment of segments) {
+          const segmentTokens = estimateTokenCount(segment.text);
+
+          if (currentChunk.tokenCount + segmentTokens > maxTokens && currentChunk.texts.length > 0) {
+            // Save current chunk
+            chunks.push({
+              text: currentChunk.texts.join(" "),
+              chunkIndex: chunks.length,
+              timestampStart: currentChunk.startTime,
+              timestampEnd: currentChunk.endTime,
+              speakers: Array.from(currentChunk.speakers),
+              tokenCount: currentChunk.tokenCount,
+            });
+
+            // Start new chunk with overlap
+            const overlapTexts: string[] = [];
+            let overlapTokenCount = 0;
+            for (let i = currentChunk.texts.length - 1; i >= 0 && overlapTokenCount < overlapTokens; i--) {
+              const text = currentChunk.texts[i];
+              const tokens = estimateTokenCount(text);
+              if (overlapTokenCount + tokens <= overlapTokens) {
+                overlapTexts.unshift(text);
+                overlapTokenCount += tokens;
+              } else {
+                break;
+              }
+            }
+
+            currentChunk = {
+              texts: overlapTexts,
+              startTime: segment.startTime,
+              endTime: segment.endTime,
+              speakers: new Set(),
+              tokenCount: overlapTokenCount,
+            };
+          }
+
+          currentChunk.texts.push(segment.text);
+          currentChunk.endTime = segment.endTime;
+          currentChunk.tokenCount += segmentTokens;
+        }
+
+        // Don't forget the last chunk
+        if (currentChunk.texts.length > 0) {
+          chunks.push({
+            text: currentChunk.texts.join(" "),
+            chunkIndex: chunks.length,
+            timestampStart: currentChunk.startTime,
+            timestampEnd: currentChunk.endTime,
+            speakers: Array.from(currentChunk.speakers),
+            tokenCount: currentChunk.tokenCount,
+          });
+        }
+      } else {
+        // Fallback to sentence-based chunking for plain text
+        const sentences = splitIntoSentences(transcript);
+        let currentChunk: { texts: string[]; tokenCount: number } = { texts: [], tokenCount: 0 };
+
+        for (const sentence of sentences) {
+          const sentenceTokens = estimateTokenCount(sentence);
+
+          if (currentChunk.tokenCount + sentenceTokens > maxTokens && currentChunk.texts.length > 0) {
+            // Save current chunk
+            chunks.push({
+              text: currentChunk.texts.join(" "),
+              chunkIndex: chunks.length,
+              tokenCount: currentChunk.tokenCount,
+            });
+
+            // Start new chunk with overlap
+            const overlapTexts: string[] = [];
+            let overlapTokenCount = 0;
+            for (let i = currentChunk.texts.length - 1; i >= 0 && overlapTokenCount < overlapTokens; i--) {
+              const text = currentChunk.texts[i];
+              const tokens = estimateTokenCount(text);
+              if (overlapTokenCount + tokens <= overlapTokens) {
+                overlapTexts.unshift(text);
+                overlapTokenCount += tokens;
+              } else {
+                break;
+              }
+            }
+
+            currentChunk = {
+              texts: overlapTexts,
+              tokenCount: overlapTokenCount,
+            };
+          }
+
+          currentChunk.texts.push(sentence);
+          currentChunk.tokenCount += sentenceTokens;
+        }
+
+        // Don't forget the last chunk
+        if (currentChunk.texts.length > 0) {
+          chunks.push({
+            text: currentChunk.texts.join(" "),
+            chunkIndex: chunks.length,
+            tokenCount: currentChunk.tokenCount,
+          });
+        }
+      }
+
+      return chunks;
+    });
+
+  const embedTranscriptChunks = (
+    chunks: readonly TextChunk[],
+  ): Effect.Effect<readonly ChunkEmbedding[], AIServiceError> =>
+    Effect.gen(function* () {
+      if (chunks.length === 0) {
+        return [];
+      }
+
+      const texts = chunks.map((c) => c.text);
+      const embeddings = yield* generateEmbeddings(texts);
+
+      return chunks.map((chunk, i) => ({
+        chunk,
+        embedding: embeddings[i],
+      }));
+    });
+
+  const processTranscript = (
+    transcript: string,
+    segments?: readonly TranscriptSegment[],
+    config?: ChunkConfig,
+  ): Effect.Effect<readonly ChunkEmbedding[], AIServiceError> =>
+    Effect.gen(function* () {
+      const chunks = yield* chunkTranscript(transcript, segments, config);
+      return yield* embedTranscriptChunks(chunks);
+    });
+
+  return {
+    generateEmbedding,
+    generateEmbeddings,
+    chunkTranscript,
+    embedTranscriptChunks,
+    processTranscript,
+  } satisfies EmbeddingServiceInterface;
+});
+
+// =============================================================================
+// Embedding Layer
+// =============================================================================
+
+export const EmbeddingLive = Layer.effect(Embedding, makeEmbeddingService);
+
+// =============================================================================
+// Embedding Helper Functions
+// =============================================================================
+
+/**
+ * Generate an embedding for a single text
+ */
+export const generateEmbedding = (text: string): Effect.Effect<readonly number[], AIServiceError, Embedding> =>
+  Effect.gen(function* () {
+    const embedding = yield* Embedding;
+    return yield* embedding.generateEmbedding(text);
+  });
+
+/**
+ * Generate embeddings for multiple texts
+ */
+export const generateEmbeddings = (
+  texts: readonly string[],
+): Effect.Effect<readonly (readonly number[])[], AIServiceError, Embedding> =>
+  Effect.gen(function* () {
+    const embedding = yield* Embedding;
+    return yield* embedding.generateEmbeddings(texts);
+  });
+
+/**
+ * Chunk a transcript into segments
+ */
+export const chunkTranscript = (
+  transcript: string,
+  segments?: readonly TranscriptSegment[],
+  config?: ChunkConfig,
+): Effect.Effect<readonly TextChunk[], never, Embedding> =>
+  Effect.gen(function* () {
+    const embedding = yield* Embedding;
+    return yield* embedding.chunkTranscript(transcript, segments, config);
+  });
+
+/**
+ * Process a full transcript into embeddings
+ */
+export const processTranscript = (
+  transcript: string,
+  segments?: readonly TranscriptSegment[],
+  config?: ChunkConfig,
+): Effect.Effect<readonly ChunkEmbedding[], AIServiceError, Embedding> =>
+  Effect.gen(function* () {
+    const embedding = yield* Embedding;
+    return yield* embedding.processTranscript(transcript, segments, config);
+  });

--- a/src/lib/effect/services/index.ts
+++ b/src/lib/effect/services/index.ts
@@ -291,6 +291,21 @@ export {
   sendTrialEndingNotification,
   sendVideoProcessingNotification,
 } from "./email-notifications";
+// Embedding Service
+export type {
+  ChunkConfig,
+  ChunkEmbedding,
+  EmbeddingServiceInterface,
+  TextChunk,
+} from "./embedding";
+export {
+  chunkTranscript,
+  Embedding,
+  EmbeddingLive,
+  generateEmbedding,
+  generateEmbeddings,
+  processTranscript,
+} from "./embedding";
 // GitHub Service
 export type {
   GitHubCommit,
@@ -514,6 +529,23 @@ export {
   search,
   updateSavedSearch,
 } from "./search-repository";
+// Semantic Search Repository
+export type {
+  SemanticSearchParams,
+  SemanticSearchRepositoryService,
+  SemanticSearchResult,
+  SemanticSearchResultWithVideo,
+  SimilarVideoResult,
+  SimilarVideosParams,
+} from "./semantic-search-repository";
+export {
+  findSimilarVideos,
+  SemanticSearchRepository,
+  SemanticSearchRepositoryLive,
+  saveTranscriptChunks,
+  semanticSearch,
+  semanticSearchWithVideos,
+} from "./semantic-search-repository";
 export type { CreateSeriesInput, SeriesRepositoryService, UpdateSeriesInput } from "./series-repository";
 // Series Repository
 export {

--- a/src/lib/effect/services/semantic-search-repository.ts
+++ b/src/lib/effect/services/semantic-search-repository.ts
@@ -1,0 +1,604 @@
+/**
+ * Semantic Search Repository Service using Effect-TS
+ *
+ * Provides type-safe database operations for semantic search using vector embeddings.
+ * Supports storing transcript chunks with embeddings and performing similarity searches.
+ */
+
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { Context, Effect, Layer } from "effect";
+import {
+  decisions,
+  type NewTranscriptChunk,
+  type TranscriptChunk,
+  transcriptChunks,
+  users,
+  videos,
+} from "@/lib/db/schema";
+import type { VideoWithAuthor } from "@/lib/types";
+import { DatabaseError, NotFoundError } from "../errors";
+import { Database } from "./database";
+import type { ChunkEmbedding } from "./embedding";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Result of a semantic search operation
+ */
+export interface SemanticSearchResult {
+  readonly contentType: "transcript_chunk" | "decision";
+  readonly contentId: string;
+  readonly videoId: string;
+  readonly similarity: number;
+  readonly textPreview: string;
+  readonly timestampStart?: number;
+  readonly timestampEnd?: number;
+}
+
+/**
+ * Result of a semantic search with full video info
+ */
+export interface SemanticSearchResultWithVideo extends SemanticSearchResult {
+  readonly video?: VideoWithAuthor;
+}
+
+/**
+ * Similar video result
+ */
+export interface SimilarVideoResult {
+  readonly videoId: string;
+  readonly similarity: number;
+  readonly matchingChunks: number;
+  readonly video?: VideoWithAuthor;
+}
+
+/**
+ * Parameters for semantic search
+ */
+export interface SemanticSearchParams {
+  readonly queryEmbedding: readonly number[];
+  readonly organizationId: string;
+  readonly limit?: number;
+  readonly threshold?: number;
+  readonly contentTypes?: readonly ("transcript_chunk" | "decision")[];
+  readonly videoIds?: readonly string[];
+  readonly channelIds?: readonly string[];
+}
+
+/**
+ * Parameters for finding similar videos
+ */
+export interface SimilarVideosParams {
+  readonly videoId: string;
+  readonly organizationId: string;
+  readonly limit?: number;
+  readonly threshold?: number;
+}
+
+export interface SemanticSearchRepositoryService {
+  /**
+   * Store transcript chunks with embeddings for a video
+   */
+  readonly saveTranscriptChunks: (
+    videoId: string,
+    organizationId: string,
+    chunks: readonly ChunkEmbedding[],
+  ) => Effect.Effect<readonly TranscriptChunk[], DatabaseError>;
+
+  /**
+   * Delete all transcript chunks for a video
+   */
+  readonly deleteTranscriptChunks: (videoId: string) => Effect.Effect<void, DatabaseError>;
+
+  /**
+   * Check if a video has embeddings
+   */
+  readonly hasEmbeddings: (videoId: string) => Effect.Effect<boolean, DatabaseError>;
+
+  /**
+   * Perform semantic search across transcript chunks and decisions
+   */
+  readonly semanticSearch: (
+    params: SemanticSearchParams,
+  ) => Effect.Effect<readonly SemanticSearchResult[], DatabaseError>;
+
+  /**
+   * Perform semantic search with full video information
+   */
+  readonly semanticSearchWithVideos: (
+    params: SemanticSearchParams,
+  ) => Effect.Effect<readonly SemanticSearchResultWithVideo[], DatabaseError>;
+
+  /**
+   * Find videos similar to a given video
+   */
+  readonly findSimilarVideos: (
+    params: SimilarVideosParams,
+  ) => Effect.Effect<readonly SimilarVideoResult[], DatabaseError>;
+
+  /**
+   * Get transcript chunks for a specific video
+   */
+  readonly getTranscriptChunks: (videoId: string) => Effect.Effect<readonly TranscriptChunk[], DatabaseError>;
+
+  /**
+   * Get videos that need embeddings (have transcript but no chunks)
+   */
+  readonly getVideosNeedingEmbeddings: (
+    organizationId: string,
+    limit?: number,
+  ) => Effect.Effect<readonly { id: string; transcript: string }[], DatabaseError>;
+}
+
+// =============================================================================
+// Semantic Search Repository Tag
+// =============================================================================
+
+export class SemanticSearchRepository extends Context.Tag("SemanticSearchRepository")<
+  SemanticSearchRepository,
+  SemanticSearchRepositoryService
+>() {}
+
+// =============================================================================
+// Semantic Search Repository Implementation
+// =============================================================================
+
+const makeSemanticSearchRepositoryService = Effect.gen(function* () {
+  const { db } = yield* Database;
+
+  const saveTranscriptChunks = (
+    videoId: string,
+    organizationId: string,
+    chunks: readonly ChunkEmbedding[],
+  ): Effect.Effect<readonly TranscriptChunk[], DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        if (chunks.length === 0) {
+          return [];
+        }
+
+        // First delete existing chunks for this video
+        await db.delete(transcriptChunks).where(eq(transcriptChunks.videoId, videoId));
+
+        // Insert new chunks
+        const values: NewTranscriptChunk[] = chunks.map((c) => ({
+          videoId,
+          organizationId,
+          chunkIndex: c.chunk.chunkIndex,
+          text: c.chunk.text,
+          tokenCount: c.chunk.tokenCount,
+          timestampStart: c.chunk.timestampStart,
+          timestampEnd: c.chunk.timestampEnd,
+          speakers: c.chunk.speakers ? [...c.chunk.speakers] : undefined,
+          embedding: [...c.embedding],
+        }));
+
+        const result = await db.insert(transcriptChunks).values(values).returning();
+        return result;
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to save transcript chunks",
+          operation: "saveTranscriptChunks",
+          cause: error,
+        }),
+    });
+
+  const deleteTranscriptChunks = (videoId: string): Effect.Effect<void, DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        await db.delete(transcriptChunks).where(eq(transcriptChunks.videoId, videoId));
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to delete transcript chunks",
+          operation: "deleteTranscriptChunks",
+          cause: error,
+        }),
+    });
+
+  const hasEmbeddings = (videoId: string): Effect.Effect<boolean, DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const result = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(transcriptChunks)
+          .where(eq(transcriptChunks.videoId, videoId));
+        return Number(result[0]?.count ?? 0) > 0;
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to check embeddings",
+          operation: "hasEmbeddings",
+          cause: error,
+        }),
+    });
+
+  const semanticSearch = (
+    params: SemanticSearchParams,
+  ): Effect.Effect<readonly SemanticSearchResult[], DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const { queryEmbedding, organizationId, limit = 20, threshold = 0.7, contentTypes, videoIds } = params;
+
+        // Convert embedding array to PostgreSQL vector format
+        const embeddingStr = `[${queryEmbedding.join(",")}]`;
+
+        // Build content type filter
+        const includeChunks = !contentTypes || contentTypes.includes("transcript_chunk");
+        const includeDecisions = !contentTypes || contentTypes.includes("decision");
+
+        const results: SemanticSearchResult[] = [];
+
+        // Search transcript chunks
+        if (includeChunks) {
+          const chunkResults = await db.execute<{
+            id: string;
+            video_id: string;
+            text: string;
+            timestamp_start: number | null;
+            timestamp_end: number | null;
+            similarity: number;
+          }>(sql`
+            SELECT
+              tc.id,
+              tc.video_id,
+              LEFT(tc.text, 500) as text,
+              tc.timestamp_start,
+              tc.timestamp_end,
+              1 - (tc.embedding::vector <=> ${embeddingStr}::vector) as similarity
+            FROM transcript_chunks tc
+            WHERE tc.organization_id = ${organizationId}
+              AND tc.embedding IS NOT NULL
+              ${videoIds && videoIds.length > 0 ? sql`AND tc.video_id = ANY(${videoIds})` : sql``}
+              AND 1 - (tc.embedding::vector <=> ${embeddingStr}::vector) >= ${threshold}
+            ORDER BY similarity DESC
+            LIMIT ${limit}
+          `);
+
+          for (const row of chunkResults) {
+            results.push({
+              contentType: "transcript_chunk",
+              contentId: row.id,
+              videoId: row.video_id,
+              similarity: row.similarity,
+              textPreview: row.text,
+              timestampStart: row.timestamp_start ?? undefined,
+              timestampEnd: row.timestamp_end ?? undefined,
+            });
+          }
+        }
+
+        // Search decisions
+        if (includeDecisions) {
+          const decisionResults = await db.execute<{
+            id: string;
+            video_id: string;
+            summary: string;
+            timestamp_start: number | null;
+            timestamp_end: number | null;
+            similarity: number;
+          }>(sql`
+            SELECT
+              d.id,
+              d.video_id,
+              LEFT(d.summary, 500) as summary,
+              d.timestamp_start,
+              d.timestamp_end,
+              1 - (d.embedding_vector <=> ${embeddingStr}::vector) as similarity
+            FROM decisions d
+            WHERE d.organization_id = ${organizationId}
+              AND d.embedding_vector IS NOT NULL
+              ${videoIds && videoIds.length > 0 ? sql`AND d.video_id = ANY(${videoIds})` : sql``}
+              AND 1 - (d.embedding_vector <=> ${embeddingStr}::vector) >= ${threshold}
+            ORDER BY similarity DESC
+            LIMIT ${limit}
+          `);
+
+          for (const row of decisionResults) {
+            results.push({
+              contentType: "decision",
+              contentId: row.id,
+              videoId: row.video_id,
+              similarity: row.similarity,
+              textPreview: row.summary,
+              timestampStart: row.timestamp_start ?? undefined,
+              timestampEnd: row.timestamp_end ?? undefined,
+            });
+          }
+        }
+
+        // Sort by similarity and limit
+        return results.sort((a, b) => b.similarity - a.similarity).slice(0, limit);
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to perform semantic search",
+          operation: "semanticSearch",
+          cause: error,
+        }),
+    });
+
+  const semanticSearchWithVideos = (
+    params: SemanticSearchParams,
+  ): Effect.Effect<readonly SemanticSearchResultWithVideo[], DatabaseError> =>
+    Effect.gen(function* () {
+      const searchResults = yield* semanticSearch(params);
+
+      if (searchResults.length === 0) {
+        return [];
+      }
+
+      // Get unique video IDs
+      const videoIds = [...new Set(searchResults.map((r) => r.videoId))];
+
+      // Fetch video information
+      const videosData = yield* Effect.tryPromise({
+        try: async () => {
+          return await db
+            .select({
+              id: videos.id,
+              title: videos.title,
+              description: videos.description,
+              duration: videos.duration,
+              thumbnailUrl: videos.thumbnailUrl,
+              videoUrl: videos.videoUrl,
+              authorId: videos.authorId,
+              organizationId: videos.organizationId,
+              channelId: videos.channelId,
+              collectionId: videos.collectionId,
+              transcript: videos.transcript,
+              transcriptSegments: videos.transcriptSegments,
+              processingStatus: videos.processingStatus,
+              processingError: videos.processingError,
+              aiSummary: videos.aiSummary,
+              aiTags: videos.aiTags,
+              aiActionItems: videos.aiActionItems,
+              searchVector: videos.searchVector,
+              createdAt: videos.createdAt,
+              updatedAt: videos.updatedAt,
+              author: {
+                id: users.id,
+                email: users.email,
+                name: users.name,
+                image: users.image,
+                createdAt: users.createdAt,
+                updatedAt: users.updatedAt,
+                emailVerified: users.emailVerified,
+                role: users.role,
+                banned: users.banned,
+                banReason: users.banReason,
+                banExpires: users.banExpires,
+              },
+            })
+            .from(videos)
+            .innerJoin(users, eq(videos.authorId, users.id))
+            .where(inArray(videos.id, videoIds));
+        },
+        catch: (error) =>
+          new DatabaseError({
+            message: "Failed to fetch videos for semantic search",
+            operation: "semanticSearchWithVideos",
+            cause: error,
+          }),
+      });
+
+      // Create video lookup map - cast to unknown first to handle partial user fields
+      const videoMap = new Map(videosData.map((v) => [v.id, v as unknown as VideoWithAuthor]));
+
+      // Combine results with video info
+      return searchResults.map((result) => ({
+        ...result,
+        video: videoMap.get(result.videoId),
+      }));
+    });
+
+  const findSimilarVideos = (
+    params: SimilarVideosParams,
+  ): Effect.Effect<readonly SimilarVideoResult[], DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const { videoId, organizationId, limit = 5, threshold = 0.7 } = params;
+
+        // Use the find_similar_videos function from the migration
+        // or implement inline for more control
+        const results = await db.execute<{
+          video_id: string;
+          avg_similarity: number;
+          matching_chunks: number;
+        }>(sql`
+          WITH source_embeddings AS (
+            SELECT id, embedding
+            FROM transcript_chunks
+            WHERE video_id = ${videoId}
+              AND embedding IS NOT NULL
+          ),
+          chunk_similarities AS (
+            SELECT
+              tc.video_id,
+              tc.id as chunk_id,
+              MAX(1 - (tc.embedding::vector <=> se.embedding::vector)) as max_similarity
+            FROM transcript_chunks tc
+            CROSS JOIN source_embeddings se
+            WHERE tc.organization_id = ${organizationId}
+              AND tc.video_id != ${videoId}
+              AND tc.embedding IS NOT NULL
+            GROUP BY tc.video_id, tc.id
+          )
+          SELECT
+            cs.video_id,
+            AVG(cs.max_similarity) as avg_similarity,
+            COUNT(*)::integer as matching_chunks
+          FROM chunk_similarities cs
+          GROUP BY cs.video_id
+          HAVING AVG(cs.max_similarity) >= ${threshold}
+          ORDER BY avg_similarity DESC
+          LIMIT ${limit}
+        `);
+
+        // Fetch video details
+        const videoIds = results.map((r) => r.video_id);
+        if (videoIds.length === 0) {
+          return [];
+        }
+
+        const videosData = await db
+          .select({
+            id: videos.id,
+            title: videos.title,
+            description: videos.description,
+            duration: videos.duration,
+            thumbnailUrl: videos.thumbnailUrl,
+            videoUrl: videos.videoUrl,
+            authorId: videos.authorId,
+            organizationId: videos.organizationId,
+            channelId: videos.channelId,
+            collectionId: videos.collectionId,
+            transcript: videos.transcript,
+            transcriptSegments: videos.transcriptSegments,
+            processingStatus: videos.processingStatus,
+            processingError: videos.processingError,
+            aiSummary: videos.aiSummary,
+            aiTags: videos.aiTags,
+            aiActionItems: videos.aiActionItems,
+            searchVector: videos.searchVector,
+            createdAt: videos.createdAt,
+            updatedAt: videos.updatedAt,
+            author: {
+              id: users.id,
+              email: users.email,
+              name: users.name,
+              image: users.image,
+              createdAt: users.createdAt,
+              updatedAt: users.updatedAt,
+              emailVerified: users.emailVerified,
+              role: users.role,
+              banned: users.banned,
+              banReason: users.banReason,
+              banExpires: users.banExpires,
+            },
+          })
+          .from(videos)
+          .innerJoin(users, eq(videos.authorId, users.id))
+          .where(inArray(videos.id, videoIds));
+
+        const videoMap = new Map(videosData.map((v) => [v.id, v as unknown as VideoWithAuthor]));
+
+        return results.map((r) => ({
+          videoId: r.video_id,
+          similarity: r.avg_similarity,
+          matchingChunks: r.matching_chunks,
+          video: videoMap.get(r.video_id),
+        }));
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to find similar videos",
+          operation: "findSimilarVideos",
+          cause: error,
+        }),
+    });
+
+  const getTranscriptChunks = (videoId: string): Effect.Effect<readonly TranscriptChunk[], DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        return await db
+          .select()
+          .from(transcriptChunks)
+          .where(eq(transcriptChunks.videoId, videoId))
+          .orderBy(transcriptChunks.chunkIndex);
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to get transcript chunks",
+          operation: "getTranscriptChunks",
+          cause: error,
+        }),
+    });
+
+  const getVideosNeedingEmbeddings = (
+    organizationId: string,
+    limit = 100,
+  ): Effect.Effect<readonly { id: string; transcript: string }[], DatabaseError> =>
+    Effect.tryPromise({
+      try: async () => {
+        // Find videos with transcripts but no chunks
+        const results = await db.execute<{ id: string; transcript: string }>(sql`
+          SELECT v.id, v.transcript
+          FROM videos v
+          WHERE v.organization_id = ${organizationId}
+            AND v.transcript IS NOT NULL
+            AND v.processing_status = 'completed'
+            AND NOT EXISTS (
+              SELECT 1 FROM transcript_chunks tc WHERE tc.video_id = v.id
+            )
+          ORDER BY v.created_at DESC
+          LIMIT ${limit}
+        `);
+        return results;
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to get videos needing embeddings",
+          operation: "getVideosNeedingEmbeddings",
+          cause: error,
+        }),
+    });
+
+  return {
+    saveTranscriptChunks,
+    deleteTranscriptChunks,
+    hasEmbeddings,
+    semanticSearch,
+    semanticSearchWithVideos,
+    findSimilarVideos,
+    getTranscriptChunks,
+    getVideosNeedingEmbeddings,
+  } satisfies SemanticSearchRepositoryService;
+});
+
+// =============================================================================
+// Semantic Search Repository Layer
+// =============================================================================
+
+export const SemanticSearchRepositoryLive = Layer.effect(SemanticSearchRepository, makeSemanticSearchRepositoryService);
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+export const saveTranscriptChunks = (
+  videoId: string,
+  organizationId: string,
+  chunks: readonly ChunkEmbedding[],
+): Effect.Effect<readonly TranscriptChunk[], DatabaseError, SemanticSearchRepository> =>
+  Effect.gen(function* () {
+    const repo = yield* SemanticSearchRepository;
+    return yield* repo.saveTranscriptChunks(videoId, organizationId, chunks);
+  });
+
+export const semanticSearch = (
+  params: SemanticSearchParams,
+): Effect.Effect<readonly SemanticSearchResult[], DatabaseError, SemanticSearchRepository> =>
+  Effect.gen(function* () {
+    const repo = yield* SemanticSearchRepository;
+    return yield* repo.semanticSearch(params);
+  });
+
+export const semanticSearchWithVideos = (
+  params: SemanticSearchParams,
+): Effect.Effect<readonly SemanticSearchResultWithVideo[], DatabaseError, SemanticSearchRepository> =>
+  Effect.gen(function* () {
+    const repo = yield* SemanticSearchRepository;
+    return yield* repo.semanticSearchWithVideos(params);
+  });
+
+export const findSimilarVideos = (
+  params: SimilarVideosParams,
+): Effect.Effect<readonly SimilarVideoResult[], DatabaseError, SemanticSearchRepository> =>
+  Effect.gen(function* () {
+    const repo = yield* SemanticSearchRepository;
+    return yield* repo.findSimilarVideos(params);
+  });


### PR DESCRIPTION
This implementation enables teams to find content by meaning rather than exact keyword matches, allowing queries like "discussions about database scaling" to find videos mentioning PostgreSQL performance, sharding, read replicas, etc.

Changes:
- Add pgvector extension and transcript_chunks table migration
- Create Embedding service using OpenAI text-embedding-3-small
- Add SemanticSearchRepository for vector similarity queries
- Implement semantic search API endpoint (POST/GET /api/search/semantic)
- Add hybrid search combining keyword and semantic (POST/GET /api/search/hybrid)
- Add similar videos feature (GET /api/videos/[videoId]/similar)
- Add embeddings management (GET/POST/DELETE /api/videos/[videoId]/embeddings)
- Update runtime with Embedding and SemanticSearchRepository layers
- Add transcript_chunks schema and relations
- Document semantic search architecture