### PR TITLE
Fix bugs and improve code quality

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -89,9 +89,17 @@
         ],
         "summary": "List activity",
         "operationId": "listActivity",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -1856,12 +1864,20 @@
         ],
         "summary": "List patterns",
         "operationId": "listInsightPattern",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"
           },
           "400": {
             "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -1873,12 +1889,20 @@
         ],
         "summary": "List summary",
         "operationId": "listInsightSummary",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"
           },
           "400": {
             "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -66,9 +66,14 @@ paths:
         - Activity
       summary: List activity
       operationId: listActivity
+      security:
+        - 
+          bearerAuth:[]
       responses:
         200:
           description: Success
+        401:
+          description: Unauthorized
   /activity/stats:
     get:
       tags:
@@ -1258,22 +1263,32 @@ paths:
         - Insights
       summary: List patterns
       operationId: listInsightPattern
+      security:
+        - 
+          bearerAuth:[]
       responses:
         200:
           description: Success
         400:
           description: Invalid request
+        401:
+          description: Unauthorized
   /insights/summary:
     get:
       tags:
         - Insights
       summary: List summary
       operationId: listInsightSummary
+      security:
+        - 
+          bearerAuth:[]
       responses:
         200:
           description: Success
         400:
           description: Invalid request
+        401:
+          description: Unauthorized
   /insights/topics:
     get:
       tags:

--- a/src/lib/effect/services/slack-monitoring.ts
+++ b/src/lib/effect/services/slack-monitoring.ts
@@ -324,25 +324,28 @@ const makeSlackMonitoringService = Effect.gen(function* () {
 
   // Get the appropriate webhook URL for an event category
   const getWebhookUrl = (category: EventCategory): string | null => {
+    // Helper to safely get webhook URL or fall back to default
+    const getWithFallback = (categoryOption: Option.Option<string>): string | null => {
+      if (Option.isSome(categoryOption)) {
+        return categoryOption.value;
+      }
+      if (Option.isSome(config.defaultWebhook)) {
+        return config.defaultWebhook.value;
+      }
+      return null;
+    };
+
     switch (category) {
       case "accounts":
-        return Option.getOrElse(config.accountsWebhook, () =>
-          Option.getOrElse(config.defaultWebhook, () => null as unknown as string),
-        );
+        return getWithFallback(config.accountsWebhook);
       case "billing":
-        return Option.getOrElse(config.billingWebhook, () =>
-          Option.getOrElse(config.defaultWebhook, () => null as unknown as string),
-        );
+        return getWithFallback(config.billingWebhook);
       case "usage":
-        return Option.getOrElse(config.usageWebhook, () =>
-          Option.getOrElse(config.defaultWebhook, () => null as unknown as string),
-        );
+        return getWithFallback(config.usageWebhook);
       case "errors":
-        return Option.getOrElse(config.errorsWebhook, () =>
-          Option.getOrElse(config.defaultWebhook, () => null as unknown as string),
-        );
+        return getWithFallback(config.errorsWebhook);
       default:
-        return Option.getOrElse(config.defaultWebhook, () => null as unknown as string);
+        return Option.isSome(config.defaultWebhook) ? config.defaultWebhook.value : null;
     }
   };
 


### PR DESCRIPTION
- Fix Zapier webhook routes to use Effect.runPromiseExit pattern with handleEffectExit instead of try-catch with Effect.runPromise
- Remove nested Effect.runPromise calls inside Effect.gen blocks in Zoom and Google webhook handlers, using Effect.catchAll instead
- Fix unsafe type assertions in slack-monitoring service that could return null instead of string, breaking the type contract
- Remove unused variable _resourceId in Google webhook handler
- Fix import sorting and formatting issues