### PR TITLE
Fix invalid URL error in Next.js server

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -29,8 +29,9 @@ const getBaseURL = () => {
   if (env.NEXT_PUBLIC_VERCEL_URL) {
     return `https://${env.NEXT_PUBLIC_VERCEL_URL}`;
   }
-  // Fallback to relative URLs for local development
-  return '';
+  // Fallback to localhost for local development SSR
+  // This prevents Invalid URL errors when constructing full URLs
+  return 'http://localhost:3000';
 };
 
 export const authClient = createAuthClient({

--- a/src/lib/effect/services/request-context.ts
+++ b/src/lib/effect/services/request-context.ts
@@ -101,16 +101,28 @@ export function makeRequestContextService(input: CreateRequestContextInput = {})
 }
 
 /**
+ * Safely parse a URL, returning null if invalid
+ */
+function safeParseUrl(url: string): URL | null {
+  if (!url) return null;
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Extract request context from NextRequest headers
  */
 export function extractRequestContext(request: Request): CreateRequestContextInput {
   const headers = request.headers;
-  const url = new URL(request.url);
+  const url = safeParseUrl(request.url);
 
   return {
     // Use existing correlation ID from upstream services if present
     correlationId: headers.get('x-correlation-id') ?? headers.get('x-request-id') ?? undefined,
-    path: url.pathname,
+    path: url?.pathname,
     method: request.method,
     userAgent: headers.get('user-agent') ?? undefined,
   };

--- a/src/lib/effect/services/zoom.ts
+++ b/src/lib/effect/services/zoom.ts
@@ -368,9 +368,16 @@ const makeZoomService = Effect.gen(function* () {
     });
 
   const getDownloadUrl = (downloadUrl: string, accessToken: string): string => {
-    const url = new URL(downloadUrl);
-    url.searchParams.set('access_token', accessToken);
-    return url.toString();
+    if (!downloadUrl) {
+      throw new Error('Download URL is required');
+    }
+    try {
+      const url = new URL(downloadUrl);
+      url.searchParams.set('access_token', accessToken);
+      return url.toString();
+    } catch {
+      throw new Error(`Invalid download URL: ${downloadUrl}`);
+    }
   };
 
   const parseRecordings = (response: ZoomRecordingsResponse): ZoomRecording[] => {

--- a/src/lib/error-logging.ts
+++ b/src/lib/error-logging.ts
@@ -257,6 +257,18 @@ export function logServerError(log: ServerErrorLog): void {
 }
 
 /**
+ * Safely parse a URL, returning null if invalid
+ */
+function safeParseUrl(url: string): URL | null {
+  if (!url) return null;
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Create error context from Next.js request
  */
 export function createErrorContext(
@@ -267,13 +279,13 @@ export function createErrorContext(
     requestId?: string;
   },
 ): ErrorContext {
-  const url = new URL(request.url);
+  const url = safeParseUrl(request.url);
 
   return {
     requestId: options?.requestId || request.headers.get('x-request-id') || crypto.randomUUID(),
     userId: options?.userId,
     organizationId: options?.organizationId,
-    path: url.pathname,
+    path: url?.pathname,
     method: request.method,
   };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -130,6 +130,22 @@ async function checkRateLimit(
 }
 
 // =============================================================================
+// URL Helper
+// =============================================================================
+
+/**
+ * Safely construct a URL with a base URL, returning null if invalid
+ */
+function safeConstructUrl(path: string, baseUrl: string): URL | null {
+  if (!baseUrl) return null;
+  try {
+    return new URL(path, baseUrl);
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
 // Route Classification
 // =============================================================================
 
@@ -287,7 +303,32 @@ export async function proxy(request: NextRequest) {
       }
 
       // For page routes, redirect to sign-in
-      const signInUrl = new URL('/auth/sign-in', request.url);
+      const signInUrl = safeConstructUrl('/auth/sign-in', request.url);
+      if (!signInUrl) {
+        // Fallback: return 401 if we can't construct redirect URL
+        requestLogger.warn(
+          {
+            requestId,
+            method,
+            path: pathname,
+            status: 401,
+          },
+          `← ${method} ${pathname} 401 Unauthorized (invalid request URL)`,
+        );
+        return new NextResponse(
+          JSON.stringify({
+            error: 'Unauthorized',
+            message: 'Authentication required',
+          }),
+          {
+            status: 401,
+            headers: {
+              'Content-Type': 'application/json',
+              'x-request-id': requestId,
+            },
+          },
+        );
+      }
       signInUrl.searchParams.set('callbackUrl', pathname);
 
       requestLogger.info(
@@ -336,7 +377,32 @@ export async function proxy(request: NextRequest) {
       }
 
       // For page routes, redirect to sign-in
-      const signInUrl = new URL('/auth/sign-in', request.url);
+      const signInUrl = safeConstructUrl('/auth/sign-in', request.url);
+      if (!signInUrl) {
+        // Fallback: return 401 if we can't construct redirect URL
+        requestLogger.warn(
+          {
+            requestId,
+            method,
+            path: pathname,
+            status: 401,
+          },
+          `← ${method} ${pathname} 401 Unauthorized (invalid request URL)`,
+        );
+        return new NextResponse(
+          JSON.stringify({
+            error: 'Unauthorized',
+            message: 'Authentication required',
+          }),
+          {
+            status: 401,
+            headers: {
+              'Content-Type': 'application/json',
+              'x-request-id': requestId,
+            },
+          },
+        );
+      }
       signInUrl.searchParams.set('callbackUrl', pathname);
 
       requestLogger.info(


### PR DESCRIPTION
Add defensive handling for URL construction to prevent TypeError when request.url is empty or invalid. Changes:

- Add safeParseUrl helper in request-context.ts and error-logging.ts
- Add safeConstructUrl helper in proxy.ts for redirect URL construction
- Change auth-client.ts fallback from empty string to localhost:3000
- Add validation in zoom.ts getDownloadUrl before URL construction