### PR TITLE
Add app url to better auth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -65,6 +65,7 @@ function buildTrustedOrigins(): string[] {
 const trustedOrigins = buildTrustedOrigins();
 
 export const auth = betterAuth({
+  baseURL: getAppUrl(),
   trustedOrigins,
   database: drizzleAdapter(db, {
     provider: 'pg',


### PR DESCRIPTION
This pull request makes a small change to the authentication setup by explicitly setting the `baseURL` property in the `auth` configuration. This helps ensure the authentication system uses the correct application URL during its operations.