### PR TITLE
Fix headerbar display for logged out users

### DIFF
--- a/src/components/marketing-header.tsx
+++ b/src/components/marketing-header.tsx
@@ -30,6 +30,7 @@ export function MarketingHeader({ showDocs = true }: MarketingHeaderProps) {
 
   const handleLogout = async () => {
     try {
+      setMobileMenuOpen(false);
       await authClient.signOut();
       router.push('/');
       router.refresh();


### PR DESCRIPTION
Close the mobile menu when logging out to ensure consistent behavior with other menu actions like navigating to the dashboard.