### PR TITLE
Fix unauthorized error in request access form

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -167,7 +167,7 @@ function isApiRoute(pathname: string): boolean {
 }
 
 function isPublicApiRoute(pathname: string): boolean {
-  const publicPatterns = ['/api/health', '/api/share/'];
+  const publicPatterns = ['/api/health', '/api/share/', '/api/beta-access'];
   return publicPatterns.some((pattern) => pathname.startsWith(pattern));
 }
 


### PR DESCRIPTION
Add /api/beta-access to the list of public API routes in the middleware so that unauthenticated users can submit the beta access request form.