### PR TITLE
Fix Content Security Policy script violation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -58,20 +58,17 @@ const nextConfig: NextConfig = {
     // Content Security Policy directives
     const cspDirectives = [
       "default-src 'self'",
-      // Allow scripts from self, inline (for Next.js), eval (for development), Vercel Analytics, and Vercel Live
-      process.env.NODE_ENV === "development"
-        ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com https://vercel.live"
-        : "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
+      // Allow scripts from self, inline (for Next.js), Vercel Analytics, and Vercel Live
+      // 'unsafe-eval' is only needed in development for HMR
+      `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com https://vercel.live`,
       // Allow styles from self and inline (required for styled-components/emotion)
       "style-src 'self' 'unsafe-inline'",
       // Allow images from self, data URIs, blob URIs, and trusted domains
       "img-src 'self' data: blob: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://*.gravatar.com https://*.r2.dev https://*.r2.cloudflarestorage.com",
       // Allow fonts from self and Google Fonts
       "font-src 'self' https://fonts.gstatic.com",
-      // Allow connections to self, API endpoints, external services, Vercel Analytics, and Vercel Live (dev)
-      process.env.NODE_ENV === "development"
-        ? "connect-src 'self' https://*.r2.cloudflarestorage.com https://api.stripe.com wss://*.nuclom.com https://vitals.vercel-insights.com https://vercel.live wss://ws-us3.pusher.com"
-        : "connect-src 'self' https://*.r2.cloudflarestorage.com https://api.stripe.com wss://*.nuclom.com https://vitals.vercel-insights.com",
+      // Allow connections to self, API endpoints, external services, Vercel Analytics, and Vercel Live
+      "connect-src 'self' https://*.r2.cloudflarestorage.com https://api.stripe.com wss://*.nuclom.com https://vitals.vercel-insights.com https://vercel.live wss://ws-us3.pusher.com",
       // Allow media from self and R2 storage
       "media-src 'self' blob: https://*.r2.dev https://*.r2.cloudflarestorage.com",
       // Prevent embedding in iframes (except for allowed origins)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -34,8 +34,14 @@ const stripeClient = new Stripe(env.STRIPE_SECRET_KEY, {
 // =============================================================================
 
 /**
- * Build trusted origins from environment with strict validation
+ * Build trusted origins with strict validation
  * Only explicitly allowed origins are trusted for cross-origin requests
+ *
+ * Trusted domains:
+ * - Production: nuclom.com
+ * - Staging: staging.nuclom.com
+ * - Deploy Previews: *.vercel.app (via VERCEL_URL)
+ * - Local: localhost:5001
  */
 function buildTrustedOrigins(): string[] {
   const origins: string[] = [];
@@ -43,20 +49,23 @@ function buildTrustedOrigins(): string[] {
   // Always trust the computed app URL
   origins.push(getAppUrl());
 
-  // Add Vercel preview URL in non-production environments
-  if (env.VERCEL_URL && env.VERCEL_ENV !== 'production') {
+  // Production and staging domains
+  origins.push('https://nuclom.com');
+  origins.push('https://staging.nuclom.com');
+
+  // Vercel deployment URL (for deploy previews: *.vercel.app)
+  if (env.VERCEL_URL) {
     origins.push(`https://${env.VERCEL_URL}`);
   }
 
-  // Add production Vercel URL if set
+  // Production Vercel URL if set
   if (env.VERCEL_PROJECT_PRODUCTION_URL) {
     origins.push(`https://${env.VERCEL_PROJECT_PRODUCTION_URL}`);
   }
 
-  // Add localhost only in development
+  // Localhost for development
   if (env.NODE_ENV === 'development') {
     origins.push('http://localhost:5001');
-    origins.push('http://127.0.0.1:3000');
   }
 
   return [...new Set(origins.filter(Boolean))];


### PR DESCRIPTION
- Add vercel.live to CSP script-src and connect-src for all environments (needed for Vercel Live feedback on staging/preview deployments)
- Simplify CSP by removing redundant NODE_ENV conditionals
- Add staging.nuclom.com to trusted auth origins
- Include VERCEL_URL in trusted origins for all Vercel environments