### PR TITLE
Remove free plan and enforce 14-day Scale trial for new users

### DIFF
--- a/src/app/(main)/[organization]/layout.tsx
+++ b/src/app/(main)/[organization]/layout.tsx
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import type React from 'react';
 import { Suspense } from 'react';
+import { TrialBannerWrapper } from '@/components/billing/trial-banner-wrapper';
 import { MobileSidebar } from '@/components/dashboard/mobile-sidebar';
 import { SidebarNav } from '@/components/dashboard/sidebar-nav';
 import { TopNav } from '@/components/top-nav';
@@ -31,6 +32,12 @@ async function LayoutContent({ children, params }: LayoutProps) {
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
+      {/* Trial banner - shows days remaining when on trial */}
+      {org?.id && (
+        <Suspense fallback={null}>
+          <TrialBannerWrapper organizationId={org.id} organizationSlug={organization} />
+        </Suspense>
+      )}
       <TopNav organization={organization} organizationId={org?.id}>
         <MobileSidebar organization={organization} />
       </TopNav>

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from 'effect';
 import type { NextRequest } from 'next/server';
 import { handleEffectExit, handleEffectExitWithStatus, runApiEffect } from '@/lib/api-handler';
-import { OrganizationRepository } from '@/lib/effect';
+import { BillingRepository, OrganizationRepository } from '@/lib/effect';
 import { Auth } from '@/lib/effect/services/auth';
 import { SlackMonitoring } from '@/lib/effect/services/slack-monitoring';
 import { validateRequestBody } from '@/lib/validation';
@@ -49,6 +49,10 @@ export async function POST(request: NextRequest) {
       logo,
       userId: user.id,
     });
+
+    // Create a 14-day trial subscription for the new organization
+    const billingRepo = yield* BillingRepository;
+    yield* billingRepo.createTrialSubscription(org.id, 14);
 
     // Send Slack monitoring notification
     const slackMonitoring = yield* SlackMonitoring;

--- a/src/components/billing/subscription-card.tsx
+++ b/src/components/billing/subscription-card.tsx
@@ -56,8 +56,8 @@ const getStatusBadge = (status: string, cancelAtPeriodEnd: boolean) => {
 };
 
 // Plan display names and prices (synced with pricing.md)
+// Note: No free plan - all new users start with a 14-day Scale trial
 const PLAN_DISPLAY_INFO: Record<string, { displayName: string; monthlyPrice: number }> = {
-  free: { displayName: 'Free', monthlyPrice: 0 },
   scale: { displayName: 'Scale', monthlyPrice: 2500 }, // $25.00/user/month
   pro: { displayName: 'Pro', monthlyPrice: 4500 }, // $45.00/user/month
   enterprise: { displayName: 'Enterprise', monthlyPrice: 0 }, // Custom pricing
@@ -105,20 +105,22 @@ export function SubscriptionCard({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Current Plan</CardTitle>
-          <CardDescription>You are currently on the free plan</CardDescription>
+          <CardTitle>No Active Subscription</CardTitle>
+          <CardDescription>Your trial has expired or no subscription is active</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-2xl font-bold">Free</p>
-              <p className="text-sm text-muted-foreground">Basic features with limited storage</p>
-            </div>
-            <Badge variant="secondary">Free Tier</Badge>
-          </div>
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Subscription Required</AlertTitle>
+            <AlertDescription>
+              To continue using Nuclom, please subscribe to a plan. Your data is being preserved.
+            </AlertDescription>
+          </Alert>
         </CardContent>
         <CardFooter>
-          <p className="text-sm text-muted-foreground">Upgrade to a paid plan to unlock more features and storage.</p>
+          <p className="text-sm text-muted-foreground">
+            Choose a plan below to restore full access to your videos and features.
+          </p>
         </CardFooter>
       </Card>
     );

--- a/src/components/billing/trial-banner-wrapper.tsx
+++ b/src/components/billing/trial-banner-wrapper.tsx
@@ -1,0 +1,40 @@
+import { Effect, Option } from 'effect';
+import { createFullLayer } from '@/lib/api-handler';
+import { BillingRepository } from '@/lib/effect/services/billing-repository';
+import { TrialBanner } from './trial-banner';
+
+interface TrialBannerWrapperProps {
+  organizationId: string;
+  organizationSlug: string;
+}
+
+export async function TrialBannerWrapper({ organizationId, organizationSlug }: TrialBannerWrapperProps) {
+  // Fetch subscription status server-side
+  const effect = Effect.gen(function* () {
+    const billingRepo = yield* BillingRepository;
+    return yield* billingRepo.getSubscriptionOption(organizationId);
+  });
+
+  const result = await Effect.runPromise(
+    Effect.provide(effect, createFullLayer()).pipe(Effect.catchAll(() => Effect.succeed(Option.none()))),
+  );
+
+  // Only show banner for trial subscriptions
+  if (Option.isNone(result)) {
+    return null;
+  }
+
+  const subscription = result.value;
+
+  // Only show for trialing status (including expired trials that haven't been updated yet)
+  if (!subscription.trialEnd) {
+    return null;
+  }
+
+  // Show for trialing status or any subscription with a trial end date
+  if (subscription.status !== 'trialing' && subscription.status !== 'incomplete_expired') {
+    return null;
+  }
+
+  return <TrialBanner trialEnd={new Date(subscription.trialEnd)} organizationSlug={organizationSlug} />;
+}

--- a/src/components/billing/trial-banner.tsx
+++ b/src/components/billing/trial-banner.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { differenceInDays, format } from 'date-fns';
+import { Clock, Sparkles, X } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface TrialBannerProps {
+  trialEnd: Date;
+  organizationSlug: string;
+  className?: string;
+}
+
+export function TrialBanner({ trialEnd, organizationSlug, className }: TrialBannerProps) {
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  const daysRemaining = Math.max(0, differenceInDays(trialEnd, new Date()));
+  const isUrgent = daysRemaining <= 3;
+  const isExpired = daysRemaining === 0;
+
+  if (isDismissed && !isUrgent) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-center justify-between gap-4 px-4 py-2 text-sm',
+        isExpired
+          ? 'bg-destructive text-destructive-foreground'
+          : isUrgent
+            ? 'bg-amber-500 text-amber-950 dark:bg-amber-600 dark:text-amber-50'
+            : 'bg-primary text-primary-foreground',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {isExpired ? (
+          <>
+            <Clock className="h-4 w-4" />
+            <span className="font-medium">Your trial has expired.</span>
+            <span>Subscribe now to continue using Nuclom.</span>
+          </>
+        ) : (
+          <>
+            <Sparkles className="h-4 w-4" />
+            <span className="font-medium">
+              {daysRemaining === 1 ? '1 day' : `${daysRemaining} days`} left in your trial
+            </span>
+            <span className="hidden sm:inline">(ends {format(trialEnd, 'MMM d, yyyy')})</span>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant={isExpired || isUrgent ? 'secondary' : 'outline'}
+          className={cn(
+            'h-7 text-xs',
+            !isExpired && !isUrgent && 'bg-primary-foreground text-primary hover:bg-primary-foreground/90',
+          )}
+          asChild
+        >
+          <Link href={`/${organizationSlug}/settings/billing`}>{isExpired ? 'Subscribe Now' : 'Upgrade'}</Link>
+        </Button>
+
+        {!isUrgent && !isExpired && (
+          <button
+            type="button"
+            onClick={() => setIsDismissed(true)}
+            className="rounded-full p-1 hover:bg-primary-foreground/20"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/effect/index.ts
+++ b/src/lib/effect/index.ts
@@ -172,6 +172,9 @@ export {
   // Auth
   Auth,
   addVideoToSeries,
+  // BillingRepository
+  BillingRepository,
+  BillingRepositoryLive,
   // ClipRepository
   ClipRepository,
   ClipRepositoryLive,

--- a/src/lib/effect/services/billing.ts
+++ b/src/lib/effect/services/billing.ts
@@ -653,8 +653,8 @@ const makeBillingService = Effect.gen(function* () {
           .pipe(Effect.mapError(() => new DatabaseError({ message: 'Subscription not found' })));
 
         // Update to canceled status (Better Auth Stripe schema)
+        // Keep the plan name but mark status as canceled
         yield* billingRepo.updateSubscription(subscription.referenceId, {
-          plan: 'free',
           status: 'canceled',
           stripeSubscriptionId: null,
           canceledAt: new Date(),


### PR DESCRIPTION
- Remove free plan from DEFAULT_PLAN_LIMITS in billing-repository
- Update fallback plan limits from 'free' to 'scale' throughout
- Auto-enroll new organizations in 14-day Scale trial on creation
- Add createTrialSubscription method to BillingRepository
- Update subscription-card to show "No Active Subscription" instead of free plan
- Create TrialBanner component showing days remaining in trial
- Add TrialBannerWrapper server component that fetches subscription status
- Display trial banner at top of main app layout
- Enforce trial expiration in billing middleware (checkSubscriptionAccess, requireActiveSubscription, requireWriteAccess)
- Update organization route tests to include BillingRepository mock