### PR TITLE
Fix video upload selector and add multiple uploads

### DIFF
--- a/src/app/(main)/[organization]/upload/page.tsx
+++ b/src/app/(main)/[organization]/upload/page.tsx
@@ -7,26 +7,27 @@ import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { VideoUpload } from '@/components/video-upload';
+import { UploadHub } from '@/components/upload-hub';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { organizations } from '@/lib/db/schema';
 
 export const metadata: Metadata = {
   title: 'Upload Video',
-  description: 'Upload a new video to your organization',
+  description: 'Upload videos to your organization from multiple sources',
 };
 
 function UploadSkeleton() {
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="max-w-4xl mx-auto space-y-8">
+      <div className="max-w-5xl mx-auto space-y-8">
         <Skeleton className="h-10 w-32" />
         <div className="text-center space-y-2">
           <Skeleton className="h-9 w-48 mx-auto" />
-          <Skeleton className="h-4 w-64 mx-auto" />
+          <Skeleton className="h-4 w-96 mx-auto" />
         </div>
-        <Skeleton className="h-64 w-full rounded-lg" />
+        <Skeleton className="h-12 w-full rounded-lg" />
+        <Skeleton className="h-96 w-full rounded-lg" />
       </div>
     </div>
   );
@@ -55,7 +56,7 @@ async function UploadContent({ params }: { params: Promise<{ organization: strin
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="max-w-4xl mx-auto space-y-8">
+      <div className="max-w-5xl mx-auto space-y-8">
         {/* Header */}
         <div className="flex items-center gap-4">
           <Button variant="ghost" size="sm" asChild className="flex items-center gap-2">
@@ -67,12 +68,19 @@ async function UploadContent({ params }: { params: Promise<{ organization: strin
         </div>
 
         <div className="text-center space-y-2">
-          <h1 className="text-3xl font-bold">Upload Video</h1>
-          <p className="text-muted-foreground">Upload a new video to your organization</p>
+          <h1 className="text-3xl font-bold">Upload Videos</h1>
+          <p className="text-muted-foreground">
+            Upload videos from your computer, import from URLs, or connect to Google Drive, Zoom, and Google Meet
+          </p>
         </div>
 
-        {/* Upload Component */}
-        <VideoUpload organizationId={organizationId} authorId={authorId} redirectPath={`/${organizationSlug}/videos`} />
+        {/* Upload Hub */}
+        <UploadHub
+          organizationId={organizationId}
+          organizationSlug={organizationSlug}
+          authorId={authorId}
+          redirectPath={`/${organizationSlug}/videos`}
+        />
       </div>
     </div>
   );

--- a/src/app/api/videos/upload/url/route.ts
+++ b/src/app/api/videos/upload/url/route.ts
@@ -1,0 +1,280 @@
+/**
+ * URL Upload API
+ *
+ * Imports a video from a remote URL by downloading and re-uploading to R2.
+ */
+
+import { Effect, Schema } from 'effect';
+import { connection, type NextRequest, NextResponse } from 'next/server';
+import { createPublicLayer, mapErrorToApiResponse } from '@/lib/api-handler';
+import { auth } from '@/lib/auth';
+import { Storage, ValidationError, VideoRepository } from '@/lib/effect';
+import type { ApiResponse } from '@/lib/types';
+import { sanitizeDescription, sanitizeTitle, validate } from '@/lib/validation';
+import { processVideoWorkflow } from '@/workflows/video-processing';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+const UrlUploadRequestSchema = Schema.Struct({
+  url: Schema.String,
+  title: Schema.String,
+  description: Schema.optional(Schema.String),
+  organizationId: Schema.String,
+  authorId: Schema.String,
+  channelId: Schema.optional(Schema.String),
+  collectionId: Schema.optional(Schema.String),
+});
+
+type UrlUploadRequest = Schema.Schema.Type<typeof UrlUploadRequestSchema>;
+
+interface UrlUploadResponse {
+  videoId: string;
+  videoUrl: string;
+  processingStatus: string;
+}
+
+// Placeholder duration - will be updated during processing
+const PLACEHOLDER_DURATION = '0:00';
+
+// Supported video extensions
+const SUPPORTED_EXTENSIONS = ['mp4', 'mov', 'avi', 'mkv', 'webm', 'flv', 'wmv', 'm4v', '3gp'];
+
+// Max file size for URL imports (2GB)
+const MAX_URL_FILE_SIZE = 2 * 1024 * 1024 * 1024;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function getExtensionFromUrl(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    const pathname = urlObj.pathname.toLowerCase();
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      if (pathname.endsWith(`.${ext}`)) {
+        return ext;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function getExtensionFromContentType(contentType: string): string | null {
+  const typeMap: Record<string, string> = {
+    'video/mp4': 'mp4',
+    'video/quicktime': 'mov',
+    'video/x-msvideo': 'avi',
+    'video/x-matroska': 'mkv',
+    'video/webm': 'webm',
+    'video/x-flv': 'flv',
+    'video/x-ms-wmv': 'wmv',
+    'video/3gpp': '3gp',
+    'video/mpeg': 'mp4',
+  };
+  return typeMap[contentType] || null;
+}
+
+// =============================================================================
+// POST /api/videos/upload/url - Import video from URL
+// =============================================================================
+
+export async function POST(request: NextRequest) {
+  await connection();
+
+  // Verify authentication
+  const session = await auth.api.getSession({
+    headers: request.headers,
+  });
+
+  if (!session?.user) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: UrlUploadRequest;
+  try {
+    const rawBody = await request.json();
+    body = await Effect.runPromise(validate(UrlUploadRequestSchema, rawBody));
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { url, title, description, organizationId, authorId, channelId, collectionId } = body;
+
+  // Validate URL
+  let videoUrl: URL;
+  try {
+    videoUrl = new URL(url);
+    if (!['http:', 'https:'].includes(videoUrl.protocol)) {
+      throw new Error('Invalid protocol');
+    }
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid URL' }, { status: 400 });
+  }
+
+  const effect = Effect.gen(function* () {
+    const storage = yield* Storage;
+    const videoRepo = yield* VideoRepository;
+
+    // Check if storage is configured
+    if (!storage.isConfigured) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: 'Storage is not configured',
+        }),
+      );
+    }
+
+    // Fetch the video with HEAD request first to check content type and size
+    const headResponse = yield* Effect.tryPromise({
+      try: () =>
+        fetch(videoUrl.toString(), {
+          method: 'HEAD',
+          headers: {
+            'User-Agent': 'Nuclom Video Import/1.0',
+          },
+        }),
+      catch: () =>
+        new ValidationError({
+          message: 'Failed to access video URL. Please check if the URL is accessible.',
+        }),
+    });
+
+    if (!headResponse.ok) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: `Failed to access video URL: ${headResponse.status} ${headResponse.statusText}`,
+        }),
+      );
+    }
+
+    const contentType = headResponse.headers.get('content-type') || '';
+    const contentLength = headResponse.headers.get('content-length');
+
+    // Check file size
+    if (contentLength) {
+      const size = Number.parseInt(contentLength, 10);
+      if (size > MAX_URL_FILE_SIZE) {
+        return yield* Effect.fail(
+          new ValidationError({
+            message: 'Video file is too large. Maximum size for URL imports is 2GB.',
+          }),
+        );
+      }
+    }
+
+    // Determine file extension
+    let extension = getExtensionFromUrl(url);
+    if (!extension) {
+      extension = getExtensionFromContentType(contentType);
+    }
+    if (!extension) {
+      // Default to mp4 if we can't determine
+      extension = 'mp4';
+    }
+
+    // Download the video
+    const videoResponse = yield* Effect.tryPromise({
+      try: () =>
+        fetch(videoUrl.toString(), {
+          headers: {
+            'User-Agent': 'Nuclom Video Import/1.0',
+          },
+        }),
+      catch: () =>
+        new ValidationError({
+          message: 'Failed to download video from URL.',
+        }),
+    });
+
+    if (!videoResponse.ok || !videoResponse.body) {
+      return yield* Effect.fail(
+        new ValidationError({
+          message: `Failed to download video: ${videoResponse.status} ${videoResponse.statusText}`,
+        }),
+      );
+    }
+
+    // Convert response to buffer
+    const arrayBuffer = yield* Effect.tryPromise({
+      try: () => videoResponse.arrayBuffer(),
+      catch: () =>
+        new ValidationError({
+          message: 'Failed to read video data.',
+        }),
+    });
+
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Generate unique file key
+    const timestamp = Date.now();
+    const randomId = crypto.randomUUID().substring(0, 8);
+    const sanitizedTitle = title.replace(/[^a-zA-Z0-9]/g, '_').substring(0, 50);
+    const fileKey = `videos/${organizationId}/${timestamp}-${randomId}-${sanitizedTitle}.${extension}`;
+
+    // Upload to R2
+    yield* storage.uploadFile(buffer, fileKey, { contentType: `video/${extension}` });
+
+    // Generate presigned URL for immediate playback
+    const presignedVideoUrl = yield* storage.generatePresignedDownloadUrl(fileKey, 3600);
+
+    // Sanitize user input
+    const sanitizedTitleFinal = sanitizeTitle(title);
+    const sanitizedDescription = description ? sanitizeDescription(description) : undefined;
+
+    // Create video record
+    const video = yield* videoRepo.createVideo({
+      title: sanitizedTitleFinal,
+      description: sanitizedDescription,
+      duration: PLACEHOLDER_DURATION,
+      videoUrl: fileKey,
+      thumbnailUrl: undefined,
+      authorId,
+      organizationId,
+      channelId: channelId || undefined,
+      collectionId: collectionId || undefined,
+      processingStatus: 'pending',
+    });
+
+    return {
+      videoId: video.id,
+      videoUrl: presignedVideoUrl,
+      processingStatus: video.processingStatus,
+      videoTitle: sanitizedTitleFinal,
+    };
+  });
+
+  const runnable = Effect.provide(effect, createPublicLayer());
+  const exit = await Effect.runPromiseExit(runnable);
+
+  if (exit._tag === 'Failure') {
+    return mapErrorToApiResponse(exit.cause);
+  }
+
+  const data = exit.value;
+
+  // Trigger video processing
+  processVideoWorkflow({
+    videoId: data.videoId,
+    videoUrl: data.videoUrl,
+    videoTitle: data.videoTitle,
+    organizationId: body.organizationId,
+  }).catch((err) => {
+    console.error('[Video Processing Workflow Error]', err);
+  });
+
+  const response: ApiResponse<UrlUploadResponse> = {
+    success: true,
+    data: {
+      videoId: data.videoId,
+      videoUrl: data.videoUrl,
+      processingStatus: data.processingStatus,
+    },
+  };
+
+  return NextResponse.json(response, { status: 201 });
+}

--- a/src/components/upload-hub.tsx
+++ b/src/components/upload-hub.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { Globe, HardDrive, Laptop, Video } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { BulkVideoUpload } from '@/components/bulk-video-upload';
+import { GoogleDrivePicker } from '@/components/integrations/google-drive-picker';
+import { RecordingBrowser } from '@/components/integrations/recording-browser';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { UrlVideoUpload } from '@/components/url-video-upload';
+import { useToast } from '@/hooks/use-toast';
+
+interface UploadHubProps {
+  organizationId: string;
+  organizationSlug: string;
+  authorId: string;
+  channelId?: string;
+  collectionId?: string;
+  redirectPath?: string;
+}
+
+type UploadSource = 'computer' | 'url' | 'google-drive' | 'zoom' | 'google-meet';
+
+interface SourceOption {
+  id: UploadSource;
+  name: string;
+  description: string;
+  icon: React.ReactNode;
+  available: boolean;
+  comingSoon?: boolean;
+}
+
+export function UploadHub({
+  organizationId,
+  organizationSlug,
+  authorId,
+  channelId,
+  collectionId,
+  redirectPath,
+}: UploadHubProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<UploadSource>('computer');
+  const [showDrivePicker, setShowDrivePicker] = useState(false);
+  const [showZoomBrowser, setShowZoomBrowser] = useState(false);
+  const [showMeetBrowser, setShowMeetBrowser] = useState(false);
+
+  const handleUploadComplete = (results: Array<{ videoId: string; title: string }>) => {
+    toast({
+      title: 'Videos Uploaded',
+      description: `${results.length} video${results.length !== 1 ? 's' : ''} uploaded successfully.`,
+    });
+    if (redirectPath && results.length > 0) {
+      router.push(`${redirectPath}/${results[0].videoId}`);
+    }
+  };
+
+  const handleGoogleDriveImport = async (files: Array<{ id: string; name: string; size: number }>) => {
+    const response = await fetch('/api/integrations/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'google_drive',
+        recordings: files.map((f) => ({
+          externalId: f.id,
+          downloadUrl: `https://www.googleapis.com/drive/v3/files/${f.id}?alt=media`,
+          title: f.name.replace(/\.[^/.]+$/, ''),
+          fileSize: f.size,
+        })),
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!data.success) {
+      throw new Error(data.error || 'Import failed');
+    }
+
+    toast({
+      title: 'Import Started',
+      description: `${data.data.imported} video${data.data.imported !== 1 ? 's' : ''} are being imported.`,
+    });
+
+    setShowDrivePicker(false);
+
+    if (redirectPath) {
+      router.push(redirectPath);
+    }
+  };
+
+  const sourceOptions: SourceOption[] = [
+    {
+      id: 'computer',
+      name: 'From Computer',
+      description: 'Upload video files from your device',
+      icon: <Laptop className="h-5 w-5" />,
+      available: true,
+    },
+    {
+      id: 'url',
+      name: 'From URL',
+      description: 'Import from a direct video link',
+      icon: <Globe className="h-5 w-5" />,
+      available: true,
+    },
+    {
+      id: 'google-drive',
+      name: 'Google Drive',
+      description: 'Import from your Google Drive',
+      icon: <HardDrive className="h-5 w-5" />,
+      available: true,
+    },
+    {
+      id: 'zoom',
+      name: 'Zoom',
+      description: 'Import Zoom recordings',
+      icon: <Video className="h-5 w-5" />,
+      available: true,
+    },
+    {
+      id: 'google-meet',
+      name: 'Google Meet',
+      description: 'Import Meet recordings',
+      icon: <Video className="h-5 w-5" />,
+      available: true,
+    },
+  ];
+
+  const handleSourceSelect = (source: UploadSource) => {
+    switch (source) {
+      case 'google-drive':
+        setShowDrivePicker(true);
+        break;
+      case 'zoom':
+        setShowZoomBrowser(true);
+        break;
+      case 'google-meet':
+        setShowMeetBrowser(true);
+        break;
+      default:
+        setActiveTab(source);
+    }
+  };
+
+  const getSourceById = (id: UploadSource): SourceOption => {
+    const source = sourceOptions.find((s) => s.id === id);
+    if (!source) {
+      throw new Error(`Source ${id} not found`);
+    }
+    return source;
+  };
+
+  return (
+    <div className="space-y-6">
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as UploadSource)} className="w-full">
+        <TabsList className="grid w-full grid-cols-5 mb-6">
+          {sourceOptions.map((source) => (
+            <TabsTrigger
+              key={source.id}
+              value={source.id}
+              className="gap-2 text-xs sm:text-sm"
+              onClick={(e) => {
+                if (['google-drive', 'zoom', 'google-meet'].includes(source.id)) {
+                  e.preventDefault();
+                  handleSourceSelect(source.id);
+                }
+              }}
+            >
+              {source.icon}
+              <span className="hidden sm:inline">{source.name}</span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="computer" className="mt-0">
+          <BulkVideoUpload
+            organizationId={organizationId}
+            authorId={authorId}
+            channelId={channelId}
+            collectionId={collectionId}
+            onUploadComplete={handleUploadComplete}
+          />
+        </TabsContent>
+
+        <TabsContent value="url" className="mt-0">
+          <UrlVideoUpload
+            organizationId={organizationId}
+            authorId={authorId}
+            channelId={channelId}
+            collectionId={collectionId}
+            onUploadComplete={handleUploadComplete}
+          />
+        </TabsContent>
+
+        <TabsContent value="google-drive" className="mt-0">
+          <IntegrationSourceCard source={getSourceById('google-drive')} onSelect={() => setShowDrivePicker(true)} />
+        </TabsContent>
+
+        <TabsContent value="zoom" className="mt-0">
+          <IntegrationSourceCard source={getSourceById('zoom')} onSelect={() => setShowZoomBrowser(true)} />
+        </TabsContent>
+
+        <TabsContent value="google-meet" className="mt-0">
+          <IntegrationSourceCard source={getSourceById('google-meet')} onSelect={() => setShowMeetBrowser(true)} />
+        </TabsContent>
+      </Tabs>
+
+      {/* Integration Dialogs */}
+      <GoogleDrivePicker
+        open={showDrivePicker}
+        onClose={() => setShowDrivePicker(false)}
+        onImport={handleGoogleDriveImport}
+      />
+
+      <RecordingBrowser
+        provider="zoom"
+        open={showZoomBrowser}
+        onClose={() => setShowZoomBrowser(false)}
+        organizationSlug={organizationSlug}
+      />
+
+      <RecordingBrowser
+        provider="google_meet"
+        open={showMeetBrowser}
+        onClose={() => setShowMeetBrowser(false)}
+        organizationSlug={organizationSlug}
+      />
+    </div>
+  );
+}
+
+function IntegrationSourceCard({ source, onSelect }: { source: SourceOption; onSelect: () => void }) {
+  return (
+    <Card
+      className="w-full max-w-3xl mx-auto cursor-pointer transition-all hover:shadow-md hover:border-primary"
+      onClick={onSelect}
+    >
+      <CardHeader className="text-center">
+        <div className="mx-auto p-4 rounded-full bg-muted text-muted-foreground mb-2">{source.icon}</div>
+        <CardTitle>{source.name}</CardTitle>
+        <CardDescription>{source.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="text-center">
+        <p className="text-sm text-muted-foreground">Click to browse and select videos to import</p>
+        {source.id === 'google-drive' && (
+          <p className="text-xs text-muted-foreground mt-2">Requires Google account to be connected in settings</p>
+        )}
+        {source.id === 'zoom' && (
+          <p className="text-xs text-muted-foreground mt-2">Requires Zoom account to be connected in settings</p>
+        )}
+        {source.id === 'google-meet' && (
+          <p className="text-xs text-muted-foreground mt-2">Requires Google account to be connected in settings</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/url-video-upload.tsx
+++ b/src/components/url-video-upload.tsx
@@ -1,0 +1,421 @@
+'use client';
+
+import { AlertCircle, CheckCircle, Globe, Loader2, Plus, Trash2, Video } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useToast } from '@/hooks/use-toast';
+import { logger } from '@/lib/client-logger';
+
+interface UrlVideoUploadProps {
+  organizationId: string;
+  authorId: string;
+  channelId?: string;
+  collectionId?: string;
+  onUploadComplete?: (results: Array<{ videoId: string; title: string }>) => void;
+  onCancel?: () => void;
+}
+
+interface UrlUpload {
+  id: string;
+  url: string;
+  title: string;
+  status: 'pending' | 'validating' | 'importing' | 'completed' | 'failed';
+  progress: number;
+  error?: string;
+  videoId?: string;
+}
+
+function extractFilenameFromUrl(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    const pathname = urlObj.pathname;
+    const filename = pathname.split('/').pop() || '';
+    return filename.replace(/\.[^/.]+$/, '');
+  } catch {
+    return 'Video from URL';
+  }
+}
+
+export function UrlVideoUpload({
+  organizationId,
+  authorId,
+  channelId,
+  collectionId,
+  onUploadComplete,
+  onCancel,
+}: UrlVideoUploadProps) {
+  const { toast } = useToast();
+  const [urls, setUrls] = useState<UrlUpload[]>([]);
+  const [newUrl, setNewUrl] = useState('');
+  const [isImporting, setIsImporting] = useState(false);
+
+  const pendingUrls = urls.filter((u) => u.status === 'pending');
+  const activeUrls = urls.filter((u) => ['validating', 'importing'].includes(u.status));
+  const completedUrls = urls.filter((u) => u.status === 'completed');
+  const failedUrls = urls.filter((u) => u.status === 'failed');
+
+  const addUrl = useCallback(() => {
+    if (!newUrl.trim()) return;
+
+    // Validate URL format
+    let url = newUrl.trim();
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      url = `https://${url}`;
+    }
+
+    try {
+      new URL(url);
+    } catch {
+      toast({
+        title: 'Invalid URL',
+        description: 'Please enter a valid URL',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    // Check for duplicates
+    if (urls.some((u) => u.url === url)) {
+      toast({
+        title: 'Duplicate URL',
+        description: 'This URL has already been added',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const title = extractFilenameFromUrl(url);
+
+    setUrls((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        url,
+        title: title || 'Video from URL',
+        status: 'pending',
+        progress: 0,
+      },
+    ]);
+    setNewUrl('');
+  }, [newUrl, urls, toast]);
+
+  const removeUrl = (id: string) => {
+    setUrls((prev) => prev.filter((u) => u.id !== id));
+  };
+
+  const updateTitle = (id: string, title: string) => {
+    setUrls((prev) => prev.map((u) => (u.id === id ? { ...u, title } : u)));
+  };
+
+  const importUrl = async (upload: UrlUpload): Promise<void> => {
+    try {
+      setUrls((prev) =>
+        prev.map((u) => (u.id === upload.id ? { ...u, status: 'validating' as const, progress: 10 } : u)),
+      );
+
+      // Call the import API
+      const response = await fetch('/api/videos/upload/url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: upload.url,
+          title: upload.title,
+          organizationId,
+          authorId,
+          channelId,
+          collectionId,
+        }),
+      });
+
+      setUrls((prev) =>
+        prev.map((u) => (u.id === upload.id ? { ...u, status: 'importing' as const, progress: 50 } : u)),
+      );
+
+      const data = await response.json();
+
+      if (!data.success) {
+        throw new Error(data.error || 'Failed to import video');
+      }
+
+      setUrls((prev) =>
+        prev.map((u) =>
+          u.id === upload.id ? { ...u, status: 'completed' as const, progress: 100, videoId: data.data.videoId } : u,
+        ),
+      );
+    } catch (error) {
+      logger.error('Failed to import video from URL', error);
+      setUrls((prev) =>
+        prev.map((u) =>
+          u.id === upload.id
+            ? {
+                ...u,
+                status: 'failed' as const,
+                progress: 0,
+                error: error instanceof Error ? error.message : 'Import failed',
+              }
+            : u,
+        ),
+      );
+    }
+  };
+
+  const startImports = async () => {
+    if (pendingUrls.length === 0) return;
+
+    setIsImporting(true);
+
+    // Process imports sequentially to avoid overwhelming the server
+    for (const upload of pendingUrls) {
+      await importUrl(upload);
+    }
+
+    setIsImporting(false);
+
+    // Get final results
+    const completed = urls.filter(
+      (u): u is UrlUpload & { videoId: string } => u.status === 'completed' && u.videoId !== undefined,
+    );
+    if (completed.length > 0 && onUploadComplete) {
+      onUploadComplete(completed.map((u) => ({ videoId: u.videoId, title: u.title })));
+    }
+  };
+
+  const retryFailed = async () => {
+    setUrls((prev) =>
+      prev.map((u) =>
+        u.status === 'failed' ? { ...u, status: 'pending' as const, error: undefined, progress: 0 } : u,
+      ),
+    );
+    await startImports();
+  };
+
+  const clearCompleted = () => {
+    setUrls((prev) => prev.filter((u) => u.status !== 'completed'));
+  };
+
+  const getStatusBadge = (status: UrlUpload['status']) => {
+    switch (status) {
+      case 'pending':
+        return <Badge variant="secondary">Pending</Badge>;
+      case 'validating':
+        return (
+          <Badge variant="secondary" className="gap-1">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Validating
+          </Badge>
+        );
+      case 'importing':
+        return (
+          <Badge variant="default" className="gap-1 bg-blue-500">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Importing
+          </Badge>
+        );
+      case 'completed':
+        return (
+          <Badge variant="default" className="gap-1 bg-green-500">
+            <CheckCircle className="h-3 w-3" />
+            Complete
+          </Badge>
+        );
+      case 'failed':
+        return (
+          <Badge variant="destructive" className="gap-1">
+            <AlertCircle className="h-3 w-3" />
+            Failed
+          </Badge>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card className="w-full max-w-3xl mx-auto">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Globe className="h-5 w-5" />
+          Import from URL
+        </CardTitle>
+        <CardDescription>
+          Import videos from direct URLs. Supports direct video file links and popular video hosting platforms.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* URL Input */}
+        <div className="flex gap-2">
+          <div className="flex-1 space-y-2">
+            <Label htmlFor="video-url">Video URL</Label>
+            <div className="flex gap-2">
+              <Input
+                id="video-url"
+                type="url"
+                value={newUrl}
+                onChange={(e) => setNewUrl(e.target.value)}
+                placeholder="https://example.com/video.mp4"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addUrl();
+                  }
+                }}
+                disabled={isImporting}
+              />
+              <Button type="button" onClick={addUrl} disabled={!newUrl.trim() || isImporting}>
+                <Plus className="h-4 w-4 mr-1" />
+                Add
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Supports direct video links (.mp4, .mov, .webm, etc.) and platforms like YouTube, Vimeo, Loom
+            </p>
+          </div>
+        </div>
+
+        {/* URL List */}
+        {urls.length > 0 && (
+          <div className="space-y-4">
+            {/* Summary */}
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>
+                {urls.length} URL{urls.length !== 1 ? 's' : ''} added
+              </span>
+              <div className="flex items-center gap-4">
+                {completedUrls.length > 0 && <span className="text-green-600">{completedUrls.length} completed</span>}
+                {failedUrls.length > 0 && <span className="text-red-600">{failedUrls.length} failed</span>}
+              </div>
+            </div>
+
+            {/* Overall Progress */}
+            {isImporting && (
+              <div className="space-y-2">
+                <Progress value={(completedUrls.length / urls.length) * 100} className="h-2" />
+                <p className="text-sm text-muted-foreground text-center">
+                  Importing {activeUrls.length} of {pendingUrls.length + activeUrls.length} URLs
+                </p>
+              </div>
+            )}
+
+            {/* URL Items */}
+            <ScrollArea className="max-h-80">
+              <div className="space-y-2">
+                {urls.map((upload) => (
+                  <div
+                    key={upload.id}
+                    className={`flex items-center gap-3 p-3 rounded-lg border ${
+                      upload.status === 'failed'
+                        ? 'border-destructive/50 bg-destructive/5'
+                        : upload.status === 'completed'
+                          ? 'border-green-500/50 bg-green-500/5'
+                          : ''
+                    }`}
+                  >
+                    <Video className="h-8 w-8 text-muted-foreground shrink-0" />
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      {upload.status === 'pending' ? (
+                        <Input
+                          value={upload.title}
+                          onChange={(e) => updateTitle(upload.id, e.target.value)}
+                          className="h-7 text-sm"
+                          placeholder="Video title"
+                        />
+                      ) : (
+                        <p className="font-medium truncate text-sm">{upload.title}</p>
+                      )}
+
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span className="truncate max-w-[200px]">{upload.url}</span>
+                        {upload.error && (
+                          <>
+                            <span>-</span>
+                            <span className="text-destructive">{upload.error}</span>
+                          </>
+                        )}
+                      </div>
+
+                      {upload.status === 'importing' && <Progress value={upload.progress} className="h-1" />}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      {getStatusBadge(upload.status)}
+
+                      {(upload.status === 'pending' || upload.status === 'failed') && (
+                        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => removeUrl(upload.id)}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </div>
+        )}
+
+        {/* Error Alert */}
+        {failedUrls.length > 0 && !isImporting && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex items-center justify-between">
+              <span>
+                {failedUrls.length} import{failedUrls.length !== 1 ? 's' : ''} failed
+              </span>
+              <Button variant="outline" size="sm" onClick={retryFailed}>
+                Retry Failed
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Success Alert */}
+        {completedUrls.length === urls.length && urls.length > 0 && !isImporting && (
+          <Alert>
+            <CheckCircle className="h-4 w-4" />
+            <AlertDescription>
+              All {completedUrls.length} video{completedUrls.length !== 1 ? 's' : ''} imported successfully!
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Action Buttons */}
+        <div className="flex gap-2 pt-4">
+          {pendingUrls.length > 0 && (
+            <Button onClick={startImports} disabled={isImporting} className="flex-1">
+              {isImporting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Importing...
+                </>
+              ) : (
+                <>
+                  <Globe className="h-4 w-4 mr-2" />
+                  Import {pendingUrls.length} Video{pendingUrls.length !== 1 ? 's' : ''}
+                </>
+              )}
+            </Button>
+          )}
+
+          {completedUrls.length > 0 && !isImporting && (
+            <Button variant="outline" onClick={clearCompleted}>
+              Clear Completed
+            </Button>
+          )}
+
+          {onCancel && (
+            <Button variant="outline" onClick={onCancel} disabled={isImporting}>
+              {urls.length === 0 ? 'Cancel' : 'Close'}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/video-upload.tsx
+++ b/src/components/video-upload.tsx
@@ -334,7 +334,10 @@ export function VideoUpload({
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => setFile(null)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setFile(null);
+                }}
                 disabled={uploadState.status === 'uploading' || uploadState.status === 'processing'}
               >
                 <X className="h-4 w-4 mr-1" />
@@ -360,7 +363,10 @@ export function VideoUpload({
                 type="button"
                 variant="outline"
                 disabled={uploadState.status === 'uploading' || uploadState.status === 'processing'}
-                onClick={() => document.getElementById('video-upload')?.click()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  document.getElementById('video-upload')?.click();
+                }}
               >
                 Select Video File
               </Button>


### PR DESCRIPTION
- Fix double video selector popup bug by adding stopPropagation to button click handlers in video-upload.tsx
- Create comprehensive UploadHub component with tabs for all upload sources:
  - From Computer (bulk upload with multiple files)
  - From URL (import from direct video links)
  - Google Drive (existing integration)
  - Zoom (existing integration)
  - Google Meet (existing integration)
- Add new UrlVideoUpload component for importing videos from URLs
- Add new API endpoint /api/videos/upload/url for URL-based imports
- Update upload page to use the new UploadHub component