### PR TITLE
Fix video rename dialog and UI refresh issues

### DIFF
--- a/apps/saas/src/app/(api)/api/videos/[id]/route.ts
+++ b/apps/saas/src/app/(api)/api/videos/[id]/route.ts
@@ -6,7 +6,7 @@ import {
   runApiEffect,
   Storage,
 } from '@nuclom/lib/api-handler';
-import { ForbiddenError, ValidationError, VideoRepository } from '@nuclom/lib/effect';
+import { ForbiddenError, revalidateVideo, ValidationError, VideoRepository } from '@nuclom/lib/effect';
 import { releaseVideoCount } from '@nuclom/lib/effect/services/billing-middleware';
 import { BillingRepository } from '@nuclom/lib/effect/services/billing-repository';
 import type { UpdateVideoInput } from '@nuclom/lib/effect/services/video-repository';
@@ -174,6 +174,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     // Update video using repository
     yield* videoRepo.updateVideo(resolvedParams.id, updateData);
+
+    // Invalidate cache for this video
+    revalidateVideo(resolvedParams.id);
 
     // Fetch updated video with relations using repository
     const videoData = yield* videoRepo.getVideo(resolvedParams.id);

--- a/apps/saas/src/components/ui/dialog.tsx
+++ b/apps/saas/src/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-foreground/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-foreground/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}


### PR DESCRIPTION
- Change dialog overlay from bg-foreground/80 to bg-black/80 to fix the white-ish blur appearance in dark mode
- Add revalidateVideo() call after updating video to ensure the UI refreshes with the new video title