### PR TITLE
Add HNSW index for content_items embedding_vector column

### DIFF
--- a/apps/saas/drizzle/0009_add_hnsw_index_content_items.sql
+++ b/apps/saas/drizzle/0009_add_hnsw_index_content_items.sql
@@ -1,0 +1,6 @@
+-- Add HNSW index for efficient vector similarity search on content_items
+-- Note: For existing production databases with large datasets, consider running
+-- this index creation manually with CONCURRENTLY to avoid table locks
+
+CREATE INDEX "content_items_embedding_hnsw_idx"
+  ON "content_items" USING hnsw (embedding_vector vector_cosine_ops);

--- a/apps/saas/drizzle/meta/_journal.json
+++ b/apps/saas/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1768842691594,
       "tag": "0008_add_content_source_abstraction",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1768846614140,
+      "tag": "0009_add_hnsw_index_content_items",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds an HNSW index for efficient vector similarity search on the `content_items.embedding_vector` column.

Fixes #317

## Changes

- Added migration `0009_add_hnsw_index_content_items.sql` to create the HNSW index
- Updated Drizzle journal to include the new migration

## Why This Matters

Without the HNSW index, vector similarity queries on the `content_items` table will perform sequential scans. This becomes increasingly slow as the number of content items grows. The HNSW (Hierarchical Navigable Small World) index enables sub-linear search time for approximate nearest neighbor queries.

## Test Plan

- [x] Migration applies successfully (`pnpm db:migrate`)
- [x] Index is created with correct settings (verify with `\di content_items_embedding_hnsw_idx` in psql)
- [x] Vector similarity queries use the index (verify with `EXPLAIN ANALYZE`)

## Notes

The migration uses a standard `CREATE INDEX` instead of `CREATE INDEX CONCURRENTLY`. For existing production databases with large amounts of data, the index can be created manually using `CONCURRENTLY` to avoid table locks. This is noted in the migration file comment.