### PR TITLE
Improve better-auth imports

### DIFF
--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -4,7 +4,6 @@ import { oauthProviderClient } from '@better-auth/oauth-provider/client';
 import { passkeyClient } from '@better-auth/passkey/client';
 import { ssoClient } from '@better-auth/sso/client';
 import { stripeClient } from '@better-auth/stripe/client';
-// Client plugins don't have dedicated exports, must use barrel file
 import {
   adminClient,
   apiKeyClient,


### PR DESCRIPTION
Use dedicated import paths for Better Auth plugins where available to enable better tree-shaking and reduce bundle size. Per Better Auth best practices, plugins should be imported from dedicated paths like `better-auth/plugins/admin` instead of the barrel file.

- Server plugins with dedicated paths: admin, jwt, multiSession, oAuthProxy, organization, twoFactor
- Server plugins without dedicated paths (barrel): apiKey, lastLoginMethod, openAPI
- Client plugins: no dedicated paths available, kept barrel import