### PR TITLE
Add private beta signup blocking and waitlist flow

### DIFF
--- a/apps/saas/src/app/(auth)/auth-error/page.tsx
+++ b/apps/saas/src/app/(auth)/auth-error/page.tsx
@@ -1,14 +1,30 @@
 'use client';
 
 import { Link } from '@vercel/microfrontends/next/client';
-import { AlertCircle, ArrowLeft, Mail } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Clock, Mail } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 // Map of error codes to user-friendly messages
-const errorMessages: Record<string, { title: string; description: string; showContactSupport?: boolean }> = {
+const errorMessages: Record<
+  string,
+  {
+    title: string;
+    description: string;
+    showContactSupport?: boolean;
+    showRequestAccess?: boolean;
+    icon?: 'error' | 'beta';
+  }
+> = {
+  signup_disabled: {
+    title: 'Private Beta',
+    description:
+      "We're currently in private beta and not accepting new signups. Request access to join our waitlist and be notified when we open up.",
+    showRequestAccess: true,
+    icon: 'beta',
+  },
   email_doesnt_match: {
     title: 'Email address mismatch',
     description:
@@ -55,13 +71,30 @@ function AuthErrorContent() {
   const normalizedCode = errorCode.toLowerCase().replace(/%20/g, '_').replace(/\s+/g, '_');
   const errorInfo = errorMessages[normalizedCode] || errorMessages[errorCode] || errorMessages.default;
 
+  const isBetaError = errorInfo.icon === 'beta';
+
   return (
     <div className="w-full max-w-md">
       <Card>
         <CardHeader className="space-y-1 pb-4">
+          {isBetaError && (
+            <div className="inline-flex items-center gap-2 text-xs font-medium text-primary bg-primary/10 px-2.5 py-1 rounded-full w-fit mb-2">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+              </span>
+              Private Beta
+            </div>
+          )}
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
-              <AlertCircle className="h-5 w-5 text-destructive" />
+            <div
+              className={`flex h-10 w-10 items-center justify-center rounded-full ${isBetaError ? 'bg-primary/10' : 'bg-destructive/10'}`}
+            >
+              {isBetaError ? (
+                <Clock className="h-5 w-5 text-primary" />
+              ) : (
+                <AlertCircle className="h-5 w-5 text-destructive" />
+              )}
             </div>
             <div>
               <CardTitle className="text-xl font-semibold">{errorInfo.title}</CardTitle>
@@ -70,6 +103,11 @@ function AuthErrorContent() {
           <CardDescription className="pt-2">{errorInfo.description}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {errorInfo.showRequestAccess && (
+            <Button className="w-full" asChild>
+              <Link href="/register">Request Access</Link>
+            </Button>
+          )}
           {errorInfo.showContactSupport && (
             <Button variant="outline" className="w-full" asChild>
               <a href="mailto:support@nuclom.com">
@@ -78,18 +116,29 @@ function AuthErrorContent() {
               </a>
             </Button>
           )}
-          <Button className="w-full" asChild>
-            <Link href="/login">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Sign In
-            </Link>
-          </Button>
-          <p className="text-center text-sm text-muted-foreground">
-            Don&apos;t have an account?{' '}
-            <Link href="/register" className="text-primary hover:underline">
-              Create one
-            </Link>
-          </p>
+          {!errorInfo.showRequestAccess && (
+            <Button className="w-full" asChild>
+              <Link href="/login">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Sign In
+              </Link>
+            </Button>
+          )}
+          {errorInfo.showRequestAccess ? (
+            <p className="text-center text-sm text-muted-foreground">
+              Already have access?{' '}
+              <Link href="/login" className="text-primary hover:underline">
+                Sign in
+              </Link>
+            </p>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">
+              Don&apos;t have an account?{' '}
+              <Link href="/register" className="text-primary hover:underline">
+                Request access
+              </Link>
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/apps/saas/src/app/(auth)/login/page.tsx
+++ b/apps/saas/src/app/(auth)/login/page.tsx
@@ -1,11 +1,14 @@
+import { env } from '@nuclom/lib/env/server';
 import { Suspense } from 'react';
 import { LoginForm } from '@/components/auth/login-form';
 
 export default function LoginPage() {
+  const signupsDisabled = env.DISABLE_SIGNUPS;
+
   return (
     <div className="w-full max-w-md">
       <Suspense fallback={<div>Loading...</div>}>
-        <LoginForm />
+        <LoginForm signupsDisabled={signupsDisabled} />
       </Suspense>
     </div>
   );

--- a/apps/saas/src/components/auth/login-form.tsx
+++ b/apps/saas/src/components/auth/login-form.tsx
@@ -15,9 +15,10 @@ import { Separator } from '@/components/ui/separator';
 
 interface LoginFormProps {
   readonly redirectTo?: string;
+  readonly signupsDisabled?: boolean;
 }
 
-export function LoginForm({ redirectTo }: LoginFormProps) {
+export function LoginForm({ redirectTo, signupsDisabled }: LoginFormProps) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -103,10 +104,19 @@ export function LoginForm({ redirectTo }: LoginFormProps) {
   return (
     <Card className="w-full max-w-md mx-auto">
       <CardHeader className="space-y-1 pb-4">
+        {signupsDisabled && (
+          <div className="inline-flex items-center gap-2 text-xs font-medium text-primary bg-primary/10 px-2.5 py-1 rounded-full w-fit mb-2">
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+            </span>
+            Private Beta
+          </div>
+        )}
         <div className="flex items-center justify-between">
           <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
           <Link href={registerUrl} className="text-sm text-muted-foreground hover:text-primary transition-colors">
-            Create account
+            {signupsDisabled ? 'Request access' : 'Create account'}
           </Link>
         </div>
         <CardDescription>Sign in to your account to continue</CardDescription>


### PR DESCRIPTION
## Summary
Implements private beta mode for the application by adding the ability to disable new signups and redirect users to a waitlist/access request flow. This includes UI updates to reflect beta status and backend enforcement of signup restrictions.

## Key Changes

- **Auth Error Page**: Added new `signup_disabled` error type with dedicated UI treatment featuring a "Private Beta" badge and "Request Access" button
- **Login Form**: Added private beta indicator badge when signups are disabled, and updated signup link text to "Request access"
- **Login Page**: Passes `DISABLE_SIGNUPS` environment variable to LoginForm component
- **Auth Backend**: 
  - Added `before` hook in user creation to block new signups (including OAuth) when `DISABLE_SIGNUPS` is enabled
  - Added Slack notification for new user registrations in the `after` hook
- **Error Handling**: Normalized error code handling to support both snake_case and space-separated formats

## Implementation Details

- The private beta badge uses an animated ping indicator to draw attention
- When signups are disabled, the "Back to Sign In" button is replaced with "Request Access" on the error page
- The signup blocking is enforced at the database hook level, preventing both traditional and OAuth signups
- Slack monitoring notifications are sent for all successful user registrations
- UI conditionally displays different CTAs and messaging based on beta status