### PR TITLE
Add commit status updates to E2E test workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,21 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Set commit status to pending
+        if: ${{ github.event.inputs.triggered_by_sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.inputs.triggered_by_sha }}',
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'E2E tests are running...',
+              context: 'E2E Tests / Playwright'
+            });
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -106,3 +121,23 @@ jobs:
         uses: vercel/repository-dispatch/actions/status@v1
         with:
           name: "Vercel - nuclom-saas: E2E Tests"
+
+      - name: Set commit status to success/failure
+        if: ${{ always() && github.event.inputs.triggered_by_sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+            const description = state === 'success'
+              ? 'E2E tests passed'
+              : 'E2E tests failed';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.inputs.triggered_by_sha }}',
+              state: state,
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: description,
+              context: 'E2E Tests / Playwright'
+            });


### PR DESCRIPTION
## Summary
This PR adds GitHub commit status reporting to the E2E test workflow, enabling better visibility into test execution status when triggered by external workflows.

## Changes
- **Pending status on start**: Added a step that sets the commit status to "pending" when the workflow is triggered with a `triggered_by_sha` input, providing immediate feedback that tests have started
- **Final status on completion**: Added a step that updates the commit status to either "success" or "failure" based on the job outcome, ensuring the triggering workflow receives the final test result
- Both status updates include:
  - Direct link to the GitHub Actions run for easy access to logs
  - Descriptive messages ("E2E tests are running...", "E2E tests passed/failed")
  - Consistent context identifier ("E2E Tests / Playwright") for status grouping

## Implementation Details
- Status updates are conditional on the presence of `github.event.inputs.triggered_by_sha`, allowing the workflow to function normally when run manually or on schedule
- The final status step uses `if: ${{ always() }}` to ensure it runs regardless of previous step failures, guaranteeing status reporting even if tests fail
- Uses the GitHub REST API via `actions/github-script@v7` for reliable status updates