### PR TITLE
Add category subtitles to marketing landing page integrations

### DIFF
--- a/apps/marketing/src/components/marketing/landing-page.tsx
+++ b/apps/marketing/src/components/marketing/landing-page.tsx
@@ -21,9 +21,9 @@ const KnowledgeNetwork = lazy(() =>
 );
 
 const integrations = [
-  { icon: MessageSquare, name: 'Slack', color: 'text-pink-400', subtitle: null },
-  { icon: FileText, name: 'Notion', color: 'text-amber-400', subtitle: null },
-  { icon: Github, name: 'GitHub', color: 'text-violet-400', subtitle: null },
+  { icon: MessageSquare, name: 'Messaging', color: 'text-pink-400', subtitle: 'Slack, Discord' },
+  { icon: FileText, name: 'Documents', color: 'text-amber-400', subtitle: 'Notion, Confluence' },
+  { icon: Github, name: 'Code', color: 'text-violet-400', subtitle: 'GitHub, GitLab' },
   { icon: Video, name: 'Meetings', color: 'text-cyan-400', subtitle: 'Zoom, Meet, Teams' },
 ];
 


### PR DESCRIPTION
Change integration names from specific products (Slack, Notion, GitHub)
to categories (Messaging, Documents, Code) with product subtitles
showing the supported platforms.

https://claude.ai/code/session_011nziBnggEo6YSTMJpGMLPK