### PR TITLE
Fix Vercel deployment OOM and timeout issues

### DIFF
--- a/apps/saas/next.config.ts
+++ b/apps/saas/next.config.ts
@@ -20,6 +20,10 @@ const nextConfig: NextConfig = {
   // Optimize barrel file imports for better bundle size and faster builds
   experimental: {
     optimizePackageImports: [
+      // Internal packages with large barrel exports (CRITICAL for build performance)
+      '@nuclom/lib',
+      '@nuclom/ui',
+      '@nuclom/auth',
       // Icons
       'lucide-react',
       '@radix-ui/react-icons',
@@ -44,8 +48,10 @@ const nextConfig: NextConfig = {
       // Effect ecosystem
       'effect',
       '@effect/platform',
+      '@effect/platform-node',
       '@effect/sql',
       '@effect/sql-drizzle',
+      '@effect/sql-pg',
       // Utilities
       'date-fns',
       'lodash',
@@ -57,6 +63,11 @@ const nextConfig: NextConfig = {
       'swr',
       'posthog-js',
       'ai',
+      // SDK clients that may have barrel exports
+      '@aws-sdk/client-s3',
+      '@aws-sdk/lib-storage',
+      'drizzle-orm',
+      'stripe',
     ],
   },
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "exports": {
     "./*": "./src/*.ts",
     "./db": "./src/db/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "exports": {
     "./*": "./src/*.tsx"
   },


### PR DESCRIPTION
Add internal packages (@nuclom/lib, @nuclom/ui, @nuclom/auth) to optimizePackageImports to enable proper tree-shaking of 1000+ line barrel files. Add sideEffects: false to lib and ui packages.

Root cause: The massive barrel file at packages/lib/src/effect/services/index.ts (1007 lines, 111 exports) was being fully loaded for every import from @nuclom/lib/effect, causing memory exhaustion during builds.