### PR TITLE
Support Vercel's Skip Unaffected Projects with Turborepo detection

### DIFF
--- a/.github/workflows/e2e-trigger.yml
+++ b/.github/workflows/e2e-trigger.yml
@@ -4,6 +4,10 @@ name: E2E Trigger
 # This workflow coordinates between SaaS and Marketing deployments
 # and triggers E2E tests when deployments are ready
 #
+# With "Skip Unaffected Projects" enabled in Vercel, not all apps will be built
+# on every commit. This workflow uses Turborepo's --dry-run to detect which apps
+# will be built and only waits for those deployments.
+#
 # NOTE: repository_dispatch events only trigger workflows on the default branch.
 # The workflow will still checkout the correct commit SHA for testing.
 #
@@ -41,8 +45,65 @@ jobs:
           echo "  Git SHA: ${{ github.event.client_payload.git.sha }}"
           echo "  Git Ref: ${{ github.event.client_payload.git.ref }}"
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.git.sha }}
+          fetch-depth: 2 # Need parent commit for turbo comparison
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Detect affected apps with Turborepo
+        id: turbo-check
+        run: |
+          echo "Checking which apps are affected by this commit..."
+
+          # Use turbo build --dry-run to detect affected packages
+          # Compare against HEAD~1 to see what changed in this commit
+          SAAS_AFFECTED="false"
+          MARKETING_AFFECTED="false"
+
+          # Check if saas app is affected
+          SAAS_DRY=$(pnpm turbo build --filter=nuclom-saas --dry-run=json 2>/dev/null || echo '{"packages":[]}')
+          if echo "$SAAS_DRY" | grep -q '"nuclom-saas"'; then
+            # Further check if there are actual tasks to run (not all cached)
+            SAAS_TASKS=$(echo "$SAAS_DRY" | jq -r '.tasks | length // 0')
+            if [ "$SAAS_TASKS" -gt 0 ]; then
+              SAAS_AFFECTED="true"
+            fi
+          fi
+
+          # Check if marketing app is affected
+          MARKETING_DRY=$(pnpm turbo build --filter=nuclom-marketing --dry-run=json 2>/dev/null || echo '{"packages":[]}')
+          if echo "$MARKETING_DRY" | grep -q '"nuclom-marketing"'; then
+            MARKETING_TASKS=$(echo "$MARKETING_DRY" | jq -r '.tasks | length // 0')
+            if [ "$MARKETING_TASKS" -gt 0 ]; then
+              MARKETING_AFFECTED="true"
+            fi
+          fi
+
+          echo "Turborepo analysis:"
+          echo "  SaaS affected: $SAAS_AFFECTED"
+          echo "  Marketing affected: $MARKETING_AFFECTED"
+
+          echo "saas_affected=$SAAS_AFFECTED" >> $GITHUB_OUTPUT
+          echo "marketing_affected=$MARKETING_AFFECTED" >> $GITHUB_OUTPUT
+
       - name: Check deployments and trigger E2E
         uses: actions/github-script@v7
+        env:
+          SAAS_AFFECTED: ${{ steps.turbo-check.outputs.saas_affected }}
+          MARKETING_AFFECTED: ${{ steps.turbo-check.outputs.marketing_affected }}
         with:
           script: |
             const payload = context.payload.client_payload;
@@ -50,6 +111,10 @@ jobs:
             const currentUrl = payload.url;
             const projectName = payload.project.name;
             const gitRef = payload.git.ref;
+
+            // Get Turborepo analysis results
+            const expectSaas = process.env.SAAS_AFFECTED === 'true';
+            const expectMarketing = process.env.MARKETING_AFFECTED === 'true';
 
             // Identify deployment type from project name
             const isSaas = projectName.includes('nuclom-saas') || projectName === 'nuclom-saas';
@@ -63,6 +128,10 @@ jobs:
             console.log(`Processing ${isSaas ? 'nuclom-saas' : 'nuclom-marketing'} deployment`);
             console.log(`  SHA: ${sha}`);
             console.log(`  URL: ${currentUrl}`);
+
+            console.log(`Expected deployments (from Turborepo):`);
+            console.log(`  SaaS: ${expectSaas ? 'expected' : 'skipped (no changes)'}`);
+            console.log(`  Marketing: ${expectMarketing ? 'expected' : 'skipped (no changes)'}`);
 
             // Helper to check all deployment statuses for this SHA
             async function checkDeployments() {
@@ -98,14 +167,16 @@ jobs:
             }
 
             // Helper to trigger E2E workflow
-            async function triggerE2E(saasUrl, marketingUrl) {
+            async function triggerE2E(saasUrl, marketingUrl, testSaas, testMarketing) {
               // Use git ref from deployment, fallback to default branch
               const ref = gitRef || context.payload.repository.default_branch;
 
               console.log(`Triggering E2E workflow`);
               console.log(`  Ref: ${ref}`);
-              console.log(`  SaaS URL: ${saasUrl}`);
-              console.log(`  Marketing URL: ${marketingUrl}`);
+              console.log(`  SaaS URL: ${saasUrl || '(skipped)'}`);
+              console.log(`  Marketing URL: ${marketingUrl || '(skipped)'}`);
+              console.log(`  Test SaaS: ${testSaas}`);
+              console.log(`  Test Marketing: ${testMarketing}`);
 
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
@@ -113,8 +184,10 @@ jobs:
                 workflow_id: 'e2e.yml',
                 ref: ref,
                 inputs: {
-                  saas_url: saasUrl,
-                  marketing_url: marketingUrl,
+                  saas_url: saasUrl || '',
+                  marketing_url: marketingUrl || '',
+                  test_saas: String(testSaas),
+                  test_marketing: String(testMarketing),
                   triggered_by_sha: sha
                 }
               });
@@ -137,20 +210,20 @@ jobs:
             console.log(`  SaaS: ${saasUrl || 'not ready'}`);
             console.log(`  Marketing: ${marketingUrl || 'not ready'}`);
 
-            // Both deployments ready - trigger E2E tests
-            if (saasUrl && marketingUrl) {
-              console.log('Both deployments ready, triggering E2E tests');
-              await triggerE2E(saasUrl, marketingUrl);
+            // Check if all expected deployments are ready
+            const saasReady = !expectSaas || saasUrl;
+            const marketingReady = !expectMarketing || marketingUrl;
+
+            if (saasReady && marketingReady) {
+              console.log('All expected deployments ready, triggering E2E tests');
+              await triggerE2E(saasUrl, marketingUrl, expectSaas, expectMarketing);
               return;
             }
 
-            // Only one deployment ready - wait for the other deployment's event
-            // The concurrency group ensures only one trigger job runs at a time per SHA,
-            // so whichever deployment finishes second will see both URLs and trigger E2E
-            if (saasUrl) {
-              console.log('SaaS ready, waiting for marketing deployment event...');
-            } else if (marketingUrl) {
-              console.log('Marketing ready, waiting for SaaS deployment event...');
-            } else {
-              console.log('No deployments ready yet.');
+            // Not all expected deployments are ready - wait for the other deployment's event
+            if (!saasReady) {
+              console.log('Waiting for SaaS deployment event...');
+            }
+            if (!marketingReady) {
+              console.log('Waiting for Marketing deployment event...');
             }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,18 +2,31 @@ name: E2E Tests
 
 # This workflow is triggered by e2e-trigger.yml when Vercel deployments are ready
 # It can also be triggered manually via workflow_dispatch for testing specific URLs
+#
+# With Vercel's "Skip Unaffected Projects" enabled, not all apps may be deployed.
+# This workflow conditionally runs tests based on which apps were deployed.
 
 on:
   workflow_dispatch:
     inputs:
       saas_url:
-        description: "SaaS deployment URL (required)"
-        required: true
+        description: "SaaS deployment URL (optional if test_saas is false)"
+        required: false
         type: string
       marketing_url:
-        description: "Marketing deployment URL (required)"
-        required: true
+        description: "Marketing deployment URL (optional if test_marketing is false)"
+        required: false
         type: string
+      test_saas:
+        description: "Whether to run SaaS tests (default: true)"
+        required: false
+        type: string
+        default: "true"
+      test_marketing:
+        description: "Whether to run Marketing tests (default: true)"
+        required: false
+        type: string
+        default: "true"
       triggered_by_sha:
         description: "Commit SHA that triggered this run (set by e2e-trigger.yml)"
         required: false
@@ -34,9 +47,92 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Job to determine which tests should run
+  determine-tests:
+    name: Determine Tests
+    runs-on: ubuntu-latest
+    outputs:
+      run_saas: ${{ steps.check.outputs.run_saas }}
+      run_marketing: ${{ steps.check.outputs.run_marketing }}
+      skip_all: ${{ steps.check.outputs.skip_all }}
+
+    steps:
+      - name: Check which tests to run
+        id: check
+        run: |
+          TEST_SAAS="${{ github.event.inputs.test_saas }}"
+          TEST_MARKETING="${{ github.event.inputs.test_marketing }}"
+          SAAS_URL="${{ github.event.inputs.saas_url }}"
+          MARKETING_URL="${{ github.event.inputs.marketing_url }}"
+
+          # Default to true for manual triggers without explicit test flags
+          if [ -z "$TEST_SAAS" ]; then
+            TEST_SAAS="true"
+          fi
+          if [ -z "$TEST_MARKETING" ]; then
+            TEST_MARKETING="true"
+          fi
+
+          # Determine if we should run each test suite
+          RUN_SAAS="false"
+          RUN_MARKETING="false"
+
+          if [ "$TEST_SAAS" = "true" ] && [ -n "$SAAS_URL" ]; then
+            RUN_SAAS="true"
+          fi
+
+          if [ "$TEST_MARKETING" = "true" ] && [ -n "$MARKETING_URL" ]; then
+            RUN_MARKETING="true"
+          fi
+
+          # Check if all tests are skipped
+          SKIP_ALL="false"
+          if [ "$RUN_SAAS" = "false" ] && [ "$RUN_MARKETING" = "false" ]; then
+            SKIP_ALL="true"
+          fi
+
+          echo "run_saas=$RUN_SAAS" >> $GITHUB_OUTPUT
+          echo "run_marketing=$RUN_MARKETING" >> $GITHUB_OUTPUT
+          echo "skip_all=$SKIP_ALL" >> $GITHUB_OUTPUT
+
+          echo "Test configuration:"
+          echo "  Run SaaS tests: $RUN_SAAS"
+          echo "  Run Marketing tests: $RUN_MARKETING"
+          echo "  Skip all: $SKIP_ALL"
+
+  # Job that passes when all tests are skipped (for required checks)
+  skip-check:
+    name: Playwright (Skipped)
+    runs-on: ubuntu-latest
+    needs: determine-tests
+    if: needs.determine-tests.outputs.skip_all == 'true'
+
+    steps:
+      - name: Report skipped status
+        run: |
+          echo "All E2E tests skipped - no apps were deployed"
+          echo "This is expected when Vercel's 'Skip Unaffected Projects' skips all builds"
+
+      - name: Set commit status to success (skipped)
+        if: ${{ github.event.inputs.triggered_by_sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.inputs.triggered_by_sha }}',
+              state: 'success',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'E2E tests skipped (no apps deployed)',
+              context: 'E2E Tests / Playwright'
+            });
+
   e2e-tests:
     name: Playwright
     runs-on: ubuntu-latest
+    needs: determine-tests
+    if: needs.determine-tests.outputs.skip_all == 'false'
     timeout-minutes: 30
 
     steps:
@@ -83,21 +179,32 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter @nuclom/e2e exec playwright install chromium chromium-headless-shell --with-deps
 
-      - name: Log deployment URLs
+      - name: Log test configuration
         run: |
-          echo "SaaS URL: ${{ github.event.inputs.saas_url }}"
-          echo "Marketing URL: ${{ github.event.inputs.marketing_url || '(skipped)' }}"
-          echo "Triggered by SHA: ${{ github.event.inputs.triggered_by_sha || '(manual trigger)' }}"
+          echo "Test Configuration:"
+          echo "  SaaS URL: ${{ github.event.inputs.saas_url || '(not deployed)' }}"
+          echo "  Marketing URL: ${{ github.event.inputs.marketing_url || '(not deployed)' }}"
+          echo "  Run SaaS tests: ${{ needs.determine-tests.outputs.run_saas }}"
+          echo "  Run Marketing tests: ${{ needs.determine-tests.outputs.run_marketing }}"
+          echo "  Triggered by SHA: ${{ github.event.inputs.triggered_by_sha || '(manual trigger)' }}"
 
-      - name: Run Playwright tests
-        run: pnpm test
+      - name: Run SaaS E2E tests
+        if: needs.determine-tests.outputs.run_saas == 'true'
+        run: pnpm test:saas
         working-directory: tests/e2e
         env:
           SAAS_BASE_URL: ${{ github.event.inputs.saas_url }}
-          MARKETING_BASE_URL: ${{ github.event.inputs.marketing_url }}
           E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
           E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
           E2E_TEST_ORG: e2e-tests
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run Marketing E2E tests
+        if: needs.determine-tests.outputs.run_marketing == 'true'
+        run: pnpm test:marketing
+        working-directory: tests/e2e
+        env:
+          MARKETING_BASE_URL: ${{ github.event.inputs.marketing_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Upload Playwright report
@@ -128,9 +235,18 @@ jobs:
         with:
           script: |
             const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
-            const description = state === 'success'
-              ? 'E2E tests passed'
-              : 'E2E tests failed';
+            const runSaas = '${{ needs.determine-tests.outputs.run_saas }}' === 'true';
+            const runMarketing = '${{ needs.determine-tests.outputs.run_marketing }}' === 'true';
+
+            let description;
+            if (state === 'success') {
+              const parts = [];
+              if (runSaas) parts.push('SaaS');
+              if (runMarketing) parts.push('Marketing');
+              description = `E2E tests passed (${parts.join(' + ')})`;
+            } else {
+              description = 'E2E tests failed';
+            }
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,


### PR DESCRIPTION
Use Turborepo's --dry-run to detect which apps are affected by a commit, allowing the E2E trigger to correctly handle cases where Vercel skips building unaffected apps in the monorepo.

Changes:
- e2e-trigger.yml: Checkout repo and run turbo build --dry-run to detect affected apps, then only wait for those deployments before triggering E2E
- e2e.yml: Add test_saas/test_marketing inputs, conditionally run test suites based on which apps were deployed, and pass checks green when all tests are skipped (no apps deployed)