### PR TITLE
Fix E2E auth test flaky selector on mobile

### DIFF
--- a/tests/e2e/saas/auth.spec.ts
+++ b/tests/e2e/saas/auth.spec.ts
@@ -82,13 +82,13 @@ test.describe('Register Page', () => {
 
   test('should have OAuth buttons or beta form', async ({ page }) => {
     // If signups are enabled, GitHub OAuth button is shown
-    // If signups are disabled, private beta form is shown
+    // If signups are disabled, private beta form with "Request Access" button is shown
     const hasGithub = await page
       .getByRole('button', { name: /github/i })
       .isVisible()
       .catch(() => false);
     const hasBetaForm = await page
-      .getByText(/private beta/i)
+      .getByRole('button', { name: /request access/i })
       .isVisible()
       .catch(() => false);
     expect(hasGithub || hasBetaForm).toBeTruthy();


### PR DESCRIPTION
## Summary

- The test `should have OAuth buttons or beta form` was failing on mobile (`saas-mobile` project) because `getByText(/private beta/i)` couldn't reliably find the text inside the badge element
- The "Private Beta" text is inside a `div` with sibling `span` elements (animated dots), making text-based selection unreliable
- Changed to use `getByRole('button', { name: /request access/i })` which targets the actual submit button in `PrivateBetaForm` - a more reliable role-based selector

## Test plan

- [ ] CI E2E tests pass on all shards (including saas-mobile)
- [ ] Verifies that either GitHub OAuth button (RegisterForm) or Request Access button (PrivateBetaForm) is found