### PR TITLE
Fix upgrade dialog showing outdated data and missing usage

### DIFF
--- a/apps/saas/src/app/(org-settings)/org/[organization]/settings/billing/page.tsx
+++ b/apps/saas/src/app/(org-settings)/org/[organization]/settings/billing/page.tsx
@@ -53,12 +53,9 @@ async function getBillingData(organizationSlug: string) {
     const billing = yield* Billing;
     const plans = yield* billing.getPlans();
 
-    // Get usage summary if subscription exists
-    let usageSummary = null;
-    if (billingInfo.subscription) {
-      const summary = yield* billing.getUsageSummary(org.id).pipe(Effect.option);
-      usageSummary = Option.getOrNull(summary);
-    }
+    // Always fetch usage summary (for both subscribed and free users)
+    const summary = yield* billing.getUsageSummary(org.id).pipe(Effect.option);
+    const usageSummary = Option.getOrNull(summary);
 
     return {
       organizationId: org.id,

--- a/apps/saas/src/components/billing/billing-dashboard.tsx
+++ b/apps/saas/src/components/billing/billing-dashboard.tsx
@@ -25,7 +25,7 @@ export function BillingDashboard({
   organizationId,
   organizationSlug,
   billingInfo,
-  plans: _plans,
+  plans,
   usageSummary,
   currentUserId,
   isOwner,
@@ -71,6 +71,8 @@ export function BillingDashboard({
             organizationSlug={organizationSlug}
             currentUserId={currentUserId}
             isOwner={isOwner}
+            plans={plans}
+            usageSummary={usageSummary}
           />
         </TabsContent>
 

--- a/packages/lib/src/effect/services/billing.ts
+++ b/packages/lib/src/effect/services/billing.ts
@@ -107,9 +107,7 @@ export interface BillingServiceInterface {
   // Billing Info
   readonly getBillingInfo: (organizationId: string) => Effect.Effect<OrganizationBillingInfo, DatabaseError>;
 
-  readonly getUsageSummary: (
-    organizationId: string,
-  ) => Effect.Effect<UsageSummary, NoSubscriptionError | DatabaseError>;
+  readonly getUsageSummary: (organizationId: string) => Effect.Effect<UsageSummary, DatabaseError>;
 
   // Plan Limits
   readonly checkLimit: (


### PR DESCRIPTION
- Pass dynamic plan data from database to UpgradeDialog instead of hardcoded values
- Display current usage summary in upgrade dialog to help users make informed decisions
- Fetch usage data for all users regardless of subscription status
- Update getUsageSummary to fall back to default limits for users without subscription