### PR TITLE
Fix Vercel build: add vercel.json with correct output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
Configure the outputDirectory to match Next.js default (.next) to resolve the "Output Directory is misconfigured" error on Vercel deployments.