### PR TITLE
Remove optimizePackageImports experimental config from Next.js apps

### DIFF
--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -8,20 +8,6 @@ const nextConfig: NextConfig = {
   // Enable compression for API responses
   compress: true,
 
-  // Optimize barrel file imports for better bundle size and faster builds
-  experimental: {
-    optimizePackageImports: [
-      'lucide-react',
-      '@radix-ui/react-icons',
-      '@radix-ui/react-accordion',
-      '@radix-ui/react-dialog',
-      '@radix-ui/react-dropdown-menu',
-      '@radix-ui/react-tabs',
-      '@radix-ui/react-tooltip',
-      'framer-motion',
-    ],
-  },
-
   // Image optimization configuration
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/apps/saas/next.config.ts
+++ b/apps/saas/next.config.ts
@@ -7,11 +7,6 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   cacheComponents: true,
 
-  // Optimize barrel file imports for better bundle size and faster builds
-  experimental: {
-    optimizePackageImports: ['lucide-react', 'date-fns', 'react-day-picker', 'posthog-js'],
-  },
-
   // Image optimization configuration
   images: {
     formats: ['image/avif', 'image/webp'],


### PR DESCRIPTION
This configuration is no longer needed as Next.js handles barrel file optimization automatically in recent versions.